### PR TITLE
geom_alt props

### DIFF
--- a/data/421/186/169/421186169.geojson
+++ b/data/421/186/169/421186169.geojson
@@ -638,6 +638,9 @@
     },
     "wof:country":"MN",
     "wof:created":1459009472,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52b4f3228c5f50bd3f43772240d74c26",
     "wof:hierarchy":[
         {
@@ -649,7 +652,7 @@
         }
     ],
     "wof:id":421186169,
-    "wof:lastmodified":1566611752,
+    "wof:lastmodified":1582379209,
     "wof:name":"Ulan Bator",
     "wof:parent_id":1092033659,
     "wof:placetype":"locality",

--- a/data/856/324/39/85632439.geojson
+++ b/data/856/324/39/85632439.geojson
@@ -946,7 +946,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1020,7 +1019,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1582379196,
+    "wof:lastmodified":1583259881,
     "wof:name":"Mongolia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/324/39/85632439.geojson
+++ b/data/856/324/39/85632439.geojson
@@ -946,6 +946,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1000,6 +1001,11 @@
     },
     "wof:country":"MN",
     "wof:country_alpha3":"MNG",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"72f72d007dc1db36c6fb3c1f92a99307",
     "wof:hierarchy":[
         {
@@ -1014,7 +1020,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611603,
+    "wof:lastmodified":1582379196,
     "wof:name":"Mongolia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/747/05/85674705.geojson
+++ b/data/856/747/05/85674705.geojson
@@ -328,6 +328,9 @@
         "wk:page":"Bayan-\u00d6lgii Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b9b7dd3d2f9e79435dca06c8cbd49dc",
     "wof:hierarchy":[
         {
@@ -343,7 +346,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611606,
+    "wof:lastmodified":1582379199,
     "wof:name":"Bayan-\u00d6lgiy",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/09/85674709.geojson
+++ b/data/856/747/09/85674709.geojson
@@ -333,6 +333,9 @@
         "wk:page":"Dornogovi Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"635050409abcf5d5dfd3728782713d58",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611609,
+    "wof:lastmodified":1582379201,
     "wof:name":"Dornogovi",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/13/85674713.geojson
+++ b/data/856/747/13/85674713.geojson
@@ -326,6 +326,9 @@
         "wd:id":"Q235579"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"305b6aef765e624ee7c2a2bc6e02e14a",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611613,
+    "wof:lastmodified":1582379204,
     "wof:name":"\u00d6mn\u00f6govi",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/19/85674719.geojson
+++ b/data/856/747/19/85674719.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Khentii Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2251f2e5e2c55be23adc15582291576c",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611608,
+    "wof:lastmodified":1582379201,
     "wof:name":"Hentiy",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/21/85674721.geojson
+++ b/data/856/747/21/85674721.geojson
@@ -334,6 +334,9 @@
         "wk:page":"Arkhangai Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a498d9d17815fd68350f0b7186ea016",
     "wof:hierarchy":[
         {
@@ -349,7 +352,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611609,
+    "wof:lastmodified":1582379201,
     "wof:name":"Arhangay",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/23/85674723.geojson
+++ b/data/856/747/23/85674723.geojson
@@ -323,6 +323,9 @@
         "wk:page":"Bayankhongor Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0906a8078b0859eae832c431bc2e863a",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611612,
+    "wof:lastmodified":1582379203,
     "wof:name":"Bayanhongor",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/27/85674727.geojson
+++ b/data/856/747/27/85674727.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Zavkhan Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9634ef2b852af63c63629f09ca897ba7",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611607,
+    "wof:lastmodified":1582379200,
     "wof:name":"Dzavxan",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/31/85674731.geojson
+++ b/data/856/747/31/85674731.geojson
@@ -334,6 +334,9 @@
         "wk:page":"Govi-Altai Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8050875594e19a9981fdb2fd10d149ae",
     "wof:hierarchy":[
         {
@@ -349,7 +352,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611609,
+    "wof:lastmodified":1582379202,
     "wof:name":"Govi-Altay",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/37/85674737.geojson
+++ b/data/856/747/37/85674737.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Khovd Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"713716d06c09bdf689fbea6bf4303c65",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611610,
+    "wof:lastmodified":1582379202,
     "wof:name":"Hovd",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/41/85674741.geojson
+++ b/data/856/747/41/85674741.geojson
@@ -324,6 +324,9 @@
         "wk:page":"Kh\u00f6vsg\u00f6l Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"79609ca6ec0e0adc3e4b2a0df35364c8",
     "wof:hierarchy":[
         {
@@ -339,7 +342,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611611,
+    "wof:lastmodified":1582379202,
     "wof:name":"H\u00f6vsg\u00f6l",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/45/85674745.geojson
+++ b/data/856/747/45/85674745.geojson
@@ -329,6 +329,9 @@
         "wk:page":"Uvs Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7595d6e8ef6b322d370ae1d5ec321c3",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611607,
+    "wof:lastmodified":1582379200,
     "wof:name":"Uvs",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/49/85674749.geojson
+++ b/data/856/747/49/85674749.geojson
@@ -323,6 +323,9 @@
         "wk:page":"Bulgan Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b124e3df0b45d7b48470ef322e9504eb",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611613,
+    "wof:lastmodified":1582379204,
     "wof:name":"Bulgan",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/51/85674751.geojson
+++ b/data/856/747/51/85674751.geojson
@@ -334,6 +334,9 @@
         "wd:id":"Q234710"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae893d10beb0bf38399a943d6b3e65ee",
     "wof:hierarchy":[
         {
@@ -349,7 +352,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611606,
+    "wof:lastmodified":1582379199,
     "wof:name":"Orhon",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/57/85674757.geojson
+++ b/data/856/747/57/85674757.geojson
@@ -326,6 +326,9 @@
         "wk:page":"Dundgovi Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b102e9ffd807e98b15d2db095f7c02f",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611605,
+    "wof:lastmodified":1582379198,
     "wof:name":"Dundgovi",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/61/85674761.geojson
+++ b/data/856/747/61/85674761.geojson
@@ -324,6 +324,9 @@
         "wk:page":"Selenge Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9828919cea7117b3b90cb7cdca1307ee",
     "wof:hierarchy":[
         {
@@ -339,7 +342,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611605,
+    "wof:lastmodified":1582379198,
     "wof:name":"Selenge",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/65/85674765.geojson
+++ b/data/856/747/65/85674765.geojson
@@ -333,6 +333,9 @@
         "wk:page":"\u00d6v\u00f6rkhangai Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d917ca5973616f39feb4e61b5a27b198",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611610,
+    "wof:lastmodified":1582379202,
     "wof:name":"\u00d6v\u00f6rhangay",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/69/85674769.geojson
+++ b/data/856/747/69/85674769.geojson
@@ -327,6 +327,9 @@
         "wd:id":"Q18827"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9022b144e9b0b944cc24783580efffb6",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611605,
+    "wof:lastmodified":1582379199,
     "wof:name":"Darhan-Uul",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/77/85674777.geojson
+++ b/data/856/747/77/85674777.geojson
@@ -336,6 +336,9 @@
         "wk:page":"T\u00f6v Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae92097b6db3475f86eb2b524f4c47f2",
     "wof:hierarchy":[
         {
@@ -351,7 +354,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611612,
+    "wof:lastmodified":1582379203,
     "wof:name":"T\u00f6v",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/79/85674779.geojson
+++ b/data/856/747/79/85674779.geojson
@@ -317,6 +317,9 @@
         "wd:id":"Q236333"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a658a58393912f90033c8f5c5eaeff8a",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611611,
+    "wof:lastmodified":1582379202,
     "wof:name":"Gov\u012d-S\u00fcmber",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/83/85674783.geojson
+++ b/data/856/747/83/85674783.geojson
@@ -606,6 +606,9 @@
         "wk:page":"Ulaanbaatar"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52b4f3228c5f50bd3f43772240d74c26",
     "wof:hierarchy":[
         {
@@ -621,7 +624,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611611,
+    "wof:lastmodified":1582379203,
     "wof:name":"Ulaanbaatar",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/87/85674787.geojson
+++ b/data/856/747/87/85674787.geojson
@@ -338,6 +338,9 @@
         "wk:page":"Dornod Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"300d54af92fb4639a4609f0feacc3847",
     "wof:hierarchy":[
         {
@@ -353,7 +356,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611608,
+    "wof:lastmodified":1582379201,
     "wof:name":"Dornod",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/93/85674793.geojson
+++ b/data/856/747/93/85674793.geojson
@@ -319,6 +319,9 @@
         "wk:page":"S\u00fckhbaatar Province"
     },
     "wof:country":"MN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0c47a6f3bb970234a18047ab68aebdf",
     "wof:hierarchy":[
         {
@@ -334,7 +337,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1566611606,
+    "wof:lastmodified":1582379199,
     "wof:name":"S\u00fchbaatar",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/890/442/035/890442035.geojson
+++ b/data/890/442/035/890442035.geojson
@@ -301,6 +301,9 @@
     },
     "wof:country":"MN",
     "wof:created":1469052348,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"141ff190e597f822cb6eb1e8e6df6688",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         }
     ],
     "wof:id":890442035,
-    "wof:lastmodified":1566611754,
+    "wof:lastmodified":1582379210,
     "wof:name":"Dalandzadgad",
     "wof:parent_id":1092036353,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.