### PR TITLE
mn concordances, placetype local, and more

### DIFF
--- a/data/109/203/168/9/1092031689.geojson
+++ b/data/109/203/168/9/1092031689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.388961,
-    "geom:area_square_m":3320932492.742298,
+    "geom:area_square_m":3320931913.906565,
     "geom:bbox":"105.345356,45.93078,106.149989,46.747467",
     "geom:latitude":46.331249,
     "geom:longitude":105.705274,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.DU.AD",
         "wd:id":"Q3404341"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897796,
-    "wof:geomhash":"0eb90cb8bfa165b993598326b9b1261e",
+    "wof:geomhash":"a13609ec535a7802eb56ce02ae8565f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092031689,
-    "wof:lastmodified":1690939727,
+    "wof:lastmodified":1695886007,
     "wof:name":"Adaacag",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/173/3/1092031733.geojson
+++ b/data/109/203/173/3/1092031733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.861445,
-    "geom:area_square_m":7456934707.037444,
+    "geom:area_square_m":7456934975.221227,
     "geom:bbox":"108.513668,45.09328,110.043781,46.178899",
     "geom:latitude":45.568169,
     "geom:longitude":109.321387,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DG.AI",
         "wd:id":"Q3396440"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897797,
-    "wof:geomhash":"6265da9b5d4528e50e808293e97df44b",
+    "wof:geomhash":"2e29194420f5b7b195057f2c0b0b6cf1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092031733,
-    "wof:lastmodified":1690939740,
+    "wof:lastmodified":1695886008,
     "wof:name":"Airag",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/203/176/5/1092031765.geojson
+++ b/data/109/203/176/5/1092031765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.567723,
-    "geom:area_square_m":4490031097.563478,
+    "geom:area_square_m":4490031869.828754,
     "geom:bbox":"99.50634,49.828886,100.656367,50.809136",
     "geom:latitude":50.237312,
     "geom:longitude":100.078265,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.HG.AL",
         "wd:id":"Q2607722"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897799,
-    "wof:geomhash":"5369f93f8d17a53f77a5a3c888ccd48d",
+    "wof:geomhash":"5aa1aeeb475c31464ca3dc1d7b453eae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092031765,
-    "wof:lastmodified":1690939763,
+    "wof:lastmodified":1695886848,
     "wof:name":"Alag-Erdene",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/180/9/1092031809.geojson
+++ b/data/109/203/180/9/1092031809.geojson
@@ -97,6 +97,7 @@
         "hasc:id":"MN.DZ.AL",
         "wd:id":"Q3403731"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897800,
     "wof:geomhash":"2cfa432e178ae32c2f363534a26d1ecd",
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1092031809,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886009,
     "wof:name":"Aldarxaan",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/184/9/1092031849.geojson
+++ b/data/109/203/184/9/1092031849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.384639,
-    "geom:area_square_m":3170749442.850809,
+    "geom:area_square_m":3170749442.850464,
     "geom:bbox":"89.1849739571,47.82541,90.0821756303,48.5673810299",
     "geom:latitude":48.189586,
     "geom:longitude":89.630413,
@@ -142,9 +142,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BO.AI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897802,
-    "wof:geomhash":"808f4fe9dff217bdbbc6a8f1bd3b1611",
+    "wof:geomhash":"4cddb91a30c527c7a87adecc8721fde1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092031849,
-    "wof:lastmodified":1566611741,
+    "wof:lastmodified":1695886848,
     "wof:name":"Altai",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/189/5/1092031895.geojson
+++ b/data/109/203/189/5/1092031895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.273093,
-    "geom:area_square_m":20085782919.9286,
+    "geom:area_square_m":20085782919.929234,
     "geom:bbox":"94.460656068,42.9013270759,96.379287272,45.3152056725",
     "geom:latitude":44.385988,
     "geom:longitude":95.586091,
@@ -142,9 +142,10 @@
     "wof:concordances":{
         "hasc:id":"MN.GA.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897803,
-    "wof:geomhash":"21d2e59a0e70cb416e0db54fa3459d66",
+    "wof:geomhash":"81e73843c1fd3e37150d0cd2558daf30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092031895,
-    "wof:lastmodified":1566611719,
+    "wof:lastmodified":1695886846,
     "wof:name":"Altai",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/192/5/1092031925.geojson
+++ b/data/109/203/192/5/1092031925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.513629,
-    "geom:area_square_m":13082442652.218018,
+    "geom:area_square_m":13082442652.218212,
     "geom:bbox":"91.7801593993,44.99941,93.3816652261,46.4709880135",
     "geom:latitude":45.653107,
     "geom:longitude":92.576661,
@@ -142,9 +142,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HD.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897805,
-    "wof:geomhash":"2697fa6741388d9fbbc35a2fe31c0ea1",
+    "wof:geomhash":"87f0ff26b95d9f81863c0245f558087b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092031925,
-    "wof:lastmodified":1566611703,
+    "wof:lastmodified":1695886845,
     "wof:name":"Altai",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/196/1/1092031961.geojson
+++ b/data/109/203/196/1/1092031961.geojson
@@ -60,6 +60,7 @@
     "wof:concordances":{
         "hasc:id":"MN.SL.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897806,
     "wof:geomhash":"ef70886d7213ef244c70d36857702dcb",
@@ -72,7 +73,7 @@
         }
     ],
     "wof:id":1092031961,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886249,
     "wof:name":"Altanbulag",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/203/199/7/1092031997.geojson
+++ b/data/109/203/199/7/1092031997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.677179,
-    "geom:area_square_m":5661118765.507883,
+    "geom:area_square_m":5661119018.936825,
     "geom:bbox":"105.445671,47.065787,106.709366,47.866749",
     "geom:latitude":47.461707,
     "geom:longitude":106.135897,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"MN.TO.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897808,
-    "wof:geomhash":"f047f2bd5a2f7bd404415bf7adba9daa",
+    "wof:geomhash":"b46a7ff6de08ed2291ef1ed259c44bb5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1092031997,
-    "wof:lastmodified":1627522363,
+    "wof:lastmodified":1695886009,
     "wof:name":"Altanbulag",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/202/1/1092032021.geojson
+++ b/data/109/203/202/1/1092032021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.221509,
-    "geom:area_square_m":1798242518.754375,
+    "geom:area_square_m":1798242651.47377,
     "geom:bbox":"90.187241,48.625439,90.781521,49.323977",
     "geom:latitude":48.96381,
     "geom:longitude":90.508845,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.BO.AN",
         "wd:id":"Q2089829"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897809,
-    "wof:geomhash":"cbe3c07ba8d11b2cbbf006915fb2a1df",
+    "wof:geomhash":"8ef8efec9ec8497e22107335f3d51f99",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092032021,
-    "wof:lastmodified":1690939739,
+    "wof:lastmodified":1695886846,
     "wof:name":"Altanco'gc",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/205/9/1092032059.geojson
+++ b/data/109/203/205/9/1092032059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.824528,
-    "geom:area_square_m":7149278606.615673,
+    "geom:area_square_m":7149278404.424603,
     "geom:bbox":"109.788109,44.911302,111.025644,46.132013",
     "geom:latitude":45.474215,
     "geom:longitude":110.463487,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.DG.AL",
         "wd:id":"Q3396306"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897811,
-    "wof:geomhash":"fb5fc0ad62724d76c22fd873a34003ee",
+    "wof:geomhash":"88c5cf23c263550b3cfe541885c0244f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092032059,
-    "wof:lastmodified":1690939739,
+    "wof:lastmodified":1695886009,
     "wof:name":"Altanshiree",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/203/210/3/1092032103.geojson
+++ b/data/109/203/210/3/1092032103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.444898,
-    "geom:area_square_m":3543255570.85987,
+    "geom:area_square_m":3543255428.225546,
     "geom:bbox":"98.823468,49.550703,99.855382,50.372503",
     "geom:latitude":49.902936,
     "geom:longitude":99.392356,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.HG.AR",
         "wd:id":"Q2607728"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897812,
-    "wof:geomhash":"436b55a0962e7dd6ba174bc0fadd88b4",
+    "wof:geomhash":"1b90ed04a21d35e6b9323e974652339d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092032103,
-    "wof:lastmodified":1690939733,
+    "wof:lastmodified":1695886846,
     "wof:name":"Arbulag",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/214/1/1092032141.geojson
+++ b/data/109/203/214/1/1092032141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13561,
-    "geom:area_square_m":1124453648.504796,
+    "geom:area_square_m":1124453717.201038,
     "geom:bbox":"105.644602,47.709941,106.53451,47.995096",
     "geom:latitude":47.888368,
     "geom:longitude":106.079648,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.TO.AG",
         "wd:id":"Q3875068"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897814,
-    "wof:geomhash":"f1386b7ecad027882b5dec4ec74c4be0",
+    "wof:geomhash":"4da65831d5fc5e5ca0771c5d472984a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092032141,
-    "wof:lastmodified":1690939754,
+    "wof:lastmodified":1695886009,
     "wof:name":"Argalant",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/218/5/1092032185.geojson
+++ b/data/109/203/218/5/1092032185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005953,
-    "geom:area_square_m":50902473.210625,
+    "geom:area_square_m":50902627.094011,
     "geom:bbox":"102.749094,46.207055,102.857957,46.294698",
     "geom:latitude":46.252609,
     "geom:longitude":102.798429,
@@ -167,9 +167,10 @@
         "hasc:id":"MN.OH.AR",
         "wd:id":"Q717684"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897815,
-    "wof:geomhash":"1ba3127538f51a2f364be6f9b5859672",
+    "wof:geomhash":"425629a72fc0f420a9dd7d83e80ab897",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092032185,
-    "wof:lastmodified":1690939731,
+    "wof:lastmodified":1695886846,
     "wof:name":"Arvaixeer",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/222/5/1092032225.geojson
+++ b/data/109/203/222/5/1092032225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098396,
-    "geom:area_square_m":822401896.965295,
+    "geom:area_square_m":822402019.925656,
     "geom:bbox":"107.683623,47.31908,108.147899,47.618745",
     "geom:latitude":47.472842,
     "geom:longitude":107.947566,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.TO.AH",
         "wd:id":"Q3875058"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897817,
-    "wof:geomhash":"6aba08f69e059b66b8429a1bdc70fa9a",
+    "wof:geomhash":"a5a8ce22dfa3083cb4caa7b7c9cf032b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092032225,
-    "wof:lastmodified":1690939753,
+    "wof:lastmodified":1695886009,
     "wof:name":"Arxust",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/226/7/1092032267.geojson
+++ b/data/109/203/226/7/1092032267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.839039,
-    "geom:area_square_m":7193109816.041146,
+    "geom:area_square_m":7193109582.379469,
     "geom:bbox":"113.326731,45.639826,114.537701,46.598755",
     "geom:latitude":46.106031,
     "geom:longitude":113.912669,
@@ -89,9 +89,10 @@
         "hasc:id":"MN.SB.AS",
         "wd:id":"Q3403927"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897818,
-    "wof:geomhash":"c1bf5b1bf78e06bed4cb14d6acb226ed",
+    "wof:geomhash":"029ffc3016d6da2edae281c7ba9b705a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1092032267,
-    "wof:lastmodified":1690939733,
+    "wof:lastmodified":1695886009,
     "wof:name":"Asgat",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/203/230/5/1092032305.geojson
+++ b/data/109/203/230/5/1092032305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070401,
-    "geom:area_square_m":565128537.144366,
+    "geom:area_square_m":565128504.103385,
     "geom:bbox":"96.503154,49.374607,96.923786,49.647472",
     "geom:latitude":49.519941,
     "geom:longitude":96.710823,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DZ.AS",
         "wd:id":"Q3403829"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897820,
-    "wof:geomhash":"2a8b8a86c9e4833c13092206c91adde1",
+    "wof:geomhash":"1b5396f173434965ca89cfd831b894a0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092032305,
-    "wof:lastmodified":1690939758,
+    "wof:lastmodified":1695886010,
     "wof:name":"Asgat",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/233/9/1092032339.geojson
+++ b/data/109/203/233/9/1092032339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.855704,
-    "geom:area_square_m":7399046548.763973,
+    "geom:area_square_m":7399046386.721609,
     "geom:bbox":"98.750484,45.1561,100.33108,46.081696",
     "geom:latitude":45.630393,
     "geom:longitude":99.484805,
@@ -110,9 +110,10 @@
         "hasc:id":"MN.BH.BA",
         "wd:id":"Q2593925"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897821,
-    "wof:geomhash":"a9f00f66c61090a3b38b63f1666e3506",
+    "wof:geomhash":"01bf0d4c8c82142fe14920860c191669",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1092032339,
-    "wof:lastmodified":1690939739,
+    "wof:lastmodified":1695886012,
     "wof:name":"Baacagaan",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/238/1/1092032381.geojson
+++ b/data/109/203/238/1/1092032381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074796,
-    "geom:area_square_m":620970000.119025,
+    "geom:area_square_m":620970000.118998,
     "geom:bbox":"108.206938829,47.6671043094,108.496240818,47.9885228518",
     "geom:latitude":47.823372,
     "geom:longitude":108.343882,
@@ -112,9 +112,10 @@
     "wof:concordances":{
         "hasc:id":"MN.UB.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897822,
-    "wof:geomhash":"8934cce31010c6efc84901647ca05301",
+    "wof:geomhash":"266db4698518855e803d183d3f6dd3c5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1092032381,
-    "wof:lastmodified":1566611734,
+    "wof:lastmodified":1695886847,
     "wof:name":"Baganuur",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/203/241/1/1092032411.geojson
+++ b/data/109/203/241/1/1092032411.geojson
@@ -85,6 +85,7 @@
         "hasc:id":"MN.TO.BA",
         "wd:id":"Q3396325"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897824,
     "wof:geomhash":"b6277913bbf1093ca1ba32b72e2210fe",
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092032411,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886010,
     "wof:name":"Bagaxangai",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/203/245/3/1092032453.geojson
+++ b/data/109/203/245/3/1092032453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.511355,
-    "geom:area_square_m":12755791362.435726,
+    "geom:area_square_m":12755791362.435677,
     "geom:bbox":"112.874464907,46.3700870475,114.944179718,47.5977767743",
     "geom:latitude":46.955401,
     "geom:longitude":113.775742,
@@ -148,9 +148,10 @@
     "wof:concordances":{
         "hasc:id":"MN.SB.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897825,
-    "wof:geomhash":"0052f86fda9d8a3ae9fd05122eee6502",
+    "wof:geomhash":"3597345544c43a1308f48509d118710d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1092032453,
-    "wof:lastmodified":1566611708,
+    "wof:lastmodified":1695886846,
     "wof:name":"Baruun-Urt",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/203/249/3/1092032493.geojson
+++ b/data/109/203/249/3/1092032493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.45225,
-    "geom:area_square_m":3939078583.460676,
+    "geom:area_square_m":3939078279.902875,
     "geom:bbox":"101.094219,44.840846,101.941036,45.552589",
     "geom:latitude":45.219178,
     "geom:longitude":101.506852,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.OH.BU",
         "wd:id":"Q2353307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897827,
-    "wof:geomhash":"40f4142280dbc363c9c8238f71dcda34",
+    "wof:geomhash":"798937a60e58e6cd91c3c057a7da4141",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092032493,
-    "wof:lastmodified":1690939753,
+    "wof:lastmodified":1695886010,
     "wof:name":"Baruunbayan-Ulaan",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/253/5/1092032535.geojson
+++ b/data/109/203/253/5/1092032535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.350208,
-    "geom:area_square_m":2824390299.192521,
+    "geom:area_square_m":2824390312.841935,
     "geom:bbox":"104.410874,48.848816,105.156449,49.70504",
     "geom:latitude":49.290129,
     "geom:longitude":104.834007,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.SL.BA",
         "wd:id":"Q2748144"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897828,
-    "wof:geomhash":"e09a34e2dbdbe6f7686d2da0519710fb",
+    "wof:geomhash":"161bce1bf3fe60df78ea5236ede69d94",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092032535,
-    "wof:lastmodified":1690939756,
+    "wof:lastmodified":1695886848,
     "wof:name":"Baruunbu'ren",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/203/256/3/1092032563.geojson
+++ b/data/109/203/256/3/1092032563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.401331,
-    "geom:area_square_m":3202970965.810404,
+    "geom:area_square_m":3202971062.588931,
     "geom:bbox":"94.243968,49.530948,95.491614,50.054869",
     "geom:latitude":49.801911,
     "geom:longitude":94.866986,
@@ -110,9 +110,10 @@
         "hasc:id":"MN.UV.BA",
         "wd:id":"Q3403748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897830,
-    "wof:geomhash":"5124aab9acc079870db998e3d4c672b1",
+    "wof:geomhash":"1b062afa9c836269caf4465ff72d46cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1092032563,
-    "wof:lastmodified":1690939738,
+    "wof:lastmodified":1695886846,
     "wof:name":"Baruunturuun",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/203/260/7/1092032607.geojson
+++ b/data/109/203/260/7/1092032607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301751,
-    "geom:area_square_m":2554596422.436975,
+    "geom:area_square_m":2554596377.53736,
     "geom:bbox":"101.331113,46.531165,102.453907,47.041153",
     "geom:latitude":46.791264,
     "geom:longitude":101.932918,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.OH.BZ",
         "wd:id":"Q3402310"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897831,
-    "wof:geomhash":"1ffdfadd5e50e25cad74b6f5adf587bc",
+    "wof:geomhash":"5abe210ed767ba13e5e1827d009343f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092032607,
-    "wof:lastmodified":1690939737,
+    "wof:lastmodified":1695886010,
     "wof:name":"Bat-O'lzii",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/264/7/1092032647.geojson
+++ b/data/109/203/264/7/1092032647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.422043,
-    "geom:area_square_m":3500425196.082372,
+    "geom:area_square_m":3500425564.042575,
     "geom:bbox":"101.345183,47.512867,102.434153,48.247152",
     "geom:latitude":47.874593,
     "geom:longitude":101.876591,
@@ -116,9 +116,10 @@
         "hasc:id":"MN.AR.BA",
         "wd:id":"Q4079574"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897833,
-    "wof:geomhash":"7b1f9bb6ac37676613bd89cdaa4e0c71",
+    "wof:geomhash":"98bda4c8d9dce3c17a91c17797c014eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1092032647,
-    "wof:lastmodified":1690939758,
+    "wof:lastmodified":1695886848,
     "wof:name":"Batcengel",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/268/7/1092032687.geojson
+++ b/data/109/203/268/7/1092032687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.598272,
-    "geom:area_square_m":4953809028.915977,
+    "geom:area_square_m":4953809762.517441,
     "geom:bbox":"110.935792,47.490199,111.910217,48.484022",
     "geom:latitude":47.960486,
     "geom:longitude":111.440878,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.HN.BN",
         "wd:id":"Q4869437"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897834,
-    "wof:geomhash":"7bcaab004539dd3befe2c9dace60f61f",
+    "wof:geomhash":"3e003a82dd22c12657c3bccecba0bf9d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092032687,
-    "wof:lastmodified":1690939735,
+    "wof:lastmodified":1695886846,
     "wof:name":"Batnorov",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/272/5/1092032725.geojson
+++ b/data/109/203/272/5/1092032725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.859913,
-    "geom:area_square_m":6998034715.411454,
+    "geom:area_square_m":6998034087.858441,
     "geom:bbox":"109.08034,48.241928,110.412614,49.355252",
     "geom:latitude":48.841071,
     "geom:longitude":109.812703,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.HN.BS",
         "wd:id":"Q3404203"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897835,
-    "wof:geomhash":"f84ceb2a3219c5a53d292c07b0bafef4",
+    "wof:geomhash":"fb056454a21f1eaca579e592a85437d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092032725,
-    "wof:lastmodified":1690939734,
+    "wof:lastmodified":1695886846,
     "wof:name":"Batshireet",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/276/9/1092032769.geojson
+++ b/data/109/203/276/9/1092032769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.293856,
-    "geom:area_square_m":2411897150.327185,
+    "geom:area_square_m":2411897249.119812,
     "geom:bbox":"106.355097,48.184399,107.287371,48.649308",
     "geom:latitude":48.411148,
     "geom:longitude":106.857433,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.TO.BS",
         "wd:id":"Q3396615"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897837,
-    "wof:geomhash":"a38b55f32bebcaaf1ca8838f26c97c55",
+    "wof:geomhash":"4088e5c047c8551499bcfe39ce635ea8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092032769,
-    "wof:lastmodified":1690939753,
+    "wof:lastmodified":1695886010,
     "wof:name":"Batsu'mber",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/280/7/1092032807.geojson
+++ b/data/109/203/280/7/1092032807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.38041,
-    "geom:area_square_m":3080131804.230461,
+    "geom:area_square_m":3080131275.852672,
     "geom:bbox":"101.612056,48.784617,102.622628,49.443489",
     "geom:latitude":49.094494,
     "geom:longitude":102.098916,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.BU.BA",
         "wd:id":"Q2606143"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897838,
-    "wof:geomhash":"1fe33686ca8afdbdbad741a3bf18a8cc",
+    "wof:geomhash":"2ef2b2f644fa029cf92739338dfcdcfe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092032807,
-    "wof:lastmodified":1690939732,
+    "wof:lastmodified":1695886010,
     "wof:name":"Bayan agt",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/203/284/5/1092032845.geojson
+++ b/data/109/203/284/5/1092032845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.367415,
-    "geom:area_square_m":3011075536.024902,
+    "geom:area_square_m":3011075733.687373,
     "geom:bbox":"110.8028,48.112542,111.676897,48.874684",
     "geom:latitude":48.48816,
     "geom:longitude":111.203814,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.HN.BA",
         "wd:id":"Q3404063"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897840,
-    "wof:geomhash":"565535d9537acc2851ccf981ffa2d2a8",
+    "wof:geomhash":"b7e8b991f50be0abf0127f167a7c4136",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092032845,
-    "wof:lastmodified":1690939750,
+    "wof:lastmodified":1695886847,
     "wof:name":"Bayan-Adraga",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/288/9/1092032889.geojson
+++ b/data/109/203/288/9/1092032889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.901615,
-    "geom:area_square_m":16972931880.957363,
+    "geom:area_square_m":16972931673.195812,
     "geom:bbox":"97.778054,42.629108,99.148444,45.040198",
     "geom:latitude":43.790521,
     "geom:longitude":98.380304,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.BH.BN",
         "wd:id":"Q2089801"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897842,
-    "wof:geomhash":"c310c3291ea866e48cd77559197009b9",
+    "wof:geomhash":"775bd476940a47c0a5717ac4303240f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092032889,
-    "wof:lastmodified":1690939734,
+    "wof:lastmodified":1695886010,
     "wof:name":"Bayan-O'ndor",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/293/9/1092032939.geojson
+++ b/data/109/203/293/9/1092032939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.381704,
-    "geom:area_square_m":3249720978.565985,
+    "geom:area_square_m":3249721134.987261,
     "geom:bbox":"103.827486,46.110664,104.661369,46.905972",
     "geom:latitude":46.486376,
     "geom:longitude":104.224469,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.OH.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897844,
-    "wof:geomhash":"003aaa72c6c06c022b72b42db0c8c472",
+    "wof:geomhash":"6a6fa5214d3698dc26bafa85150db8a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092032939,
-    "wof:lastmodified":1627522364,
+    "wof:lastmodified":1695886010,
     "wof:name":"Bayan-O'ndor",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/297/9/1092032979.geojson
+++ b/data/109/203/297/9/1092032979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034058,
-    "geom:area_square_m":275980013.059945,
+    "geom:area_square_m":275980223.403423,
     "geom:bbox":"103.959526,48.9642,104.269578,49.157151",
     "geom:latitude":49.056202,
     "geom:longitude":104.110848,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.ER.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897845,
-    "wof:geomhash":"b2b19666e6c94a63055f9f249e29f92c",
+    "wof:geomhash":"d81ae56b58d6b46fa4db81aaa36ee136",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092032979,
-    "wof:lastmodified":1627522364,
+    "wof:lastmodified":1695886011,
     "wof:name":"Bayan-O'ndor",
     "wof:parent_id":85674751,
     "wof:placetype":"county",

--- a/data/109/203/301/9/1092033019.geojson
+++ b/data/109/203/301/9/1092033019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.566969,
-    "geom:area_square_m":4787807885.964953,
+    "geom:area_square_m":4787808107.654626,
     "geom:bbox":"105.364292,46.559099,106.59114,47.279326",
     "geom:latitude":46.92671,
     "geom:longitude":106.028913,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.TO.BO",
         "wd:id":"Q3396346"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897847,
-    "wof:geomhash":"cbe53914a3bcee76a6c1cf88910bc144",
+    "wof:geomhash":"021db5c628e973c427a162613431f14c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092033019,
-    "wof:lastmodified":1690939729,
+    "wof:lastmodified":1695886011,
     "wof:name":"Bayan-O'njuul",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/306/5/1092033065.geojson
+++ b/data/109/203/306/5/1092033065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.374231,
-    "geom:area_square_m":3205229603.128653,
+    "geom:area_square_m":3205229398.149702,
     "geom:bbox":"99.879451,45.76085,100.730065,46.57886",
     "geom:latitude":46.158877,
     "geom:longitude":100.315608,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.BH.BV",
         "wd:id":"Q2089871"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897848,
-    "wof:geomhash":"354ce30b88fe6a29f00c73c32cec8c0b",
+    "wof:geomhash":"cd8cd2f42dfb8c51ea25cccf2460fefd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092033065,
-    "wof:lastmodified":1690939730,
+    "wof:lastmodified":1695886011,
     "wof:name":"Bayan-Ovoo",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/309/5/1092033095.geojson
+++ b/data/109/203/309/5/1092033095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.230005,
-    "geom:area_square_m":11154044215.543261,
+    "geom:area_square_m":11154044076.542929,
     "geom:bbox":"105.260737,42.011084,106.678749,43.490665",
     "geom:latitude":42.828871,
     "geom:longitude":106.070758,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.OG.BO",
         "wd:id":"Q3403902"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897850,
-    "wof:geomhash":"bbeab09d098070370302d5e16466559c",
+    "wof:geomhash":"2e3c84541ffea036b7fda45f1508ce7d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092033095,
-    "wof:lastmodified":1690939727,
+    "wof:lastmodified":1695886011,
     "wof:name":"Bayan-Ovoo",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/314/3/1092033143.geojson
+++ b/data/109/203/314/3/1092033143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404153,
-    "geom:area_square_m":3357787246.78496,
+    "geom:area_square_m":3357787056.0902,
     "geom:bbox":"111.628664,47.347886,112.723034,48.114079",
     "geom:latitude":47.785674,
     "geom:longitude":112.097389,
@@ -92,9 +92,10 @@
         "hasc:id":"MN.HN.BO",
         "wd:id":"Q3409990"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897851,
-    "wof:geomhash":"d6608beaf65aba4e5344a04e0ba60f11",
+    "wof:geomhash":"a03ee5c47451bcb833214ea7d294f440",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092033143,
-    "wof:lastmodified":1690939744,
+    "wof:lastmodified":1695886847,
     "wof:name":"Bayan-Ovoo",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/319/1/1092033191.geojson
+++ b/data/109/203/319/1/1092033191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.692892,
-    "geom:area_square_m":5613076892.418576,
+    "geom:area_square_m":5613076970.22433,
     "geom:bbox":"112.074754,48.627456,113.367611,49.528725",
     "geom:latitude":49.069241,
     "geom:longitude":112.641367,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DD.BU",
         "wd:id":"Q3410003"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897852,
-    "wof:geomhash":"9fdd77ca32b73f4f4e7b69f2c60d40a9",
+    "wof:geomhash":"81f0b76bc14e21266db3c4028bdd6fa1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092033191,
-    "wof:lastmodified":1690939762,
+    "wof:lastmodified":1695886848,
     "wof:name":"Bayan-Uul",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/322/1/1092033221.geojson
+++ b/data/109/203/322/1/1092033221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.692103,
-    "geom:area_square_m":5829899601.88321,
+    "geom:area_square_m":5829900273.93145,
     "geom:bbox":"94.159897,46.706162,95.749974,47.586396",
     "geom:latitude":47.060315,
     "geom:longitude":95.048825,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.GA.BU",
         "wd:id":"Q2353241"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897854,
-    "wof:geomhash":"f1913e282eb405da990d3391c37860e5",
+    "wof:geomhash":"fde0a9fec68cef30e373b180b69421cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092033221,
-    "wof:lastmodified":1690939744,
+    "wof:lastmodified":1695886011,
     "wof:name":"Bayan-Uul",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/326/9/1092033269.geojson
+++ b/data/109/203/326/9/1092033269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.372067,
-    "geom:area_square_m":3146202434.526225,
+    "geom:area_square_m":3146202181.135696,
     "geom:bbox":"97.632146,46.510872,98.591915,47.236363",
     "geom:latitude":46.854141,
     "geom:longitude":98.074155,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.BH.BB",
         "wd:id":"Q2089873"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897855,
-    "wof:geomhash":"250a3f54ff4dcdd4e81d8a91e4147884",
+    "wof:geomhash":"a87a4fc753c0ed941f37fa8cd99085ab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092033269,
-    "wof:lastmodified":1690939762,
+    "wof:lastmodified":1695886011,
     "wof:name":"Bayanbulag",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/331/1/1092033311.geojson
+++ b/data/109/203/331/1/1092033311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.638069,
-    "geom:area_square_m":5558882933.105061,
+    "geom:area_square_m":5558883016.409651,
     "geom:bbox":"98.326165,44.787523,99.643913,45.80805",
     "geom:latitude":45.205344,
     "geom:longitude":98.906602,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.BH.BS",
         "wd:id":"Q3874647"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897857,
-    "wof:geomhash":"e5e8689255ba44d089b5a097783c18f4",
+    "wof:geomhash":"bf7577f9081b2f879a55d948018a944e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092033311,
-    "wof:lastmodified":1690939727,
+    "wof:lastmodified":1695886011,
     "wof:name":"Bayancagaan",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/335/3/1092033353.geojson
+++ b/data/109/203/335/3/1092033353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.692413,
-    "geom:area_square_m":5864041110.445145,
+    "geom:area_square_m":5864040871.519547,
     "geom:bbox":"106.532307,46.402657,107.884394,47.089844",
     "geom:latitude":46.771577,
     "geom:longitude":107.182942,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.TO.BT",
         "wd:id":"Q3396389"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897858,
-    "wof:geomhash":"5b564fa4eb1629ad8cc88b88106a9c03",
+    "wof:geomhash":"56a6b0e8a456dbfb0c3f4c8048ba52fe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092033353,
-    "wof:lastmodified":1690939748,
+    "wof:lastmodified":1695886011,
     "wof:name":"Bayancagaan",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/338/9/1092033389.geojson
+++ b/data/109/203/338/9/1092033389.geojson
@@ -85,6 +85,7 @@
         "hasc:id":"MN.TO.BC",
         "wd:id":"Q3396606"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897860,
     "wof:geomhash":"14a8839b6a7c547628a59c527c3df038",
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092033389,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886012,
     "wof:name":"Bayanchandmani",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/343/3/1092033433.geojson
+++ b/data/109/203/343/3/1092033433.geojson
@@ -85,6 +85,7 @@
         "hasc:id":"MN.TO.BC",
         "wd:id":"Q3396606"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897861,
     "wof:geomhash":"8ac08770e5808fb2975d0739aa87c8af",
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092033433,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886012,
     "wof:name":"Bayancogt",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/348/1/1092033481.geojson
+++ b/data/109/203/348/1/1092033481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.178949,
-    "geom:area_square_m":10644821702.999882,
+    "geom:area_square_m":10644820318.482906,
     "geom:bbox":"102.707158,42.029731,104.045964,43.857068",
     "geom:latitude":43.094672,
     "geom:longitude":103.26702,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.OG.BD",
         "wd:id":"Q3402231"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897863,
-    "wof:geomhash":"04d51e32815c20c5bbbb96b0a5163df1",
+    "wof:geomhash":"d5afee43af2d3e50d88c6592b88a4ac9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092033481,
-    "wof:lastmodified":1690939741,
+    "wof:lastmodified":1695886012,
     "wof:name":"Bayandalai",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/350/9/1092033509.geojson
+++ b/data/109/203/350/9/1092033509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.873345,
-    "geom:area_square_m":7550966787.655869,
+    "geom:area_square_m":7550966903.851898,
     "geom:bbox":"111.732013,45.061011,112.991422,46.206984",
     "geom:latitude":45.634744,
     "geom:longitude":112.339392,
@@ -92,9 +92,10 @@
         "hasc:id":"MN.SB.BD",
         "wd:id":"Q3402329"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897864,
-    "wof:geomhash":"19f4f58a44a59a2822db1c06d8982238",
+    "wof:geomhash":"062e806b5ea28b6a526c30e5ffca3d27",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092033509,
-    "wof:lastmodified":1690939745,
+    "wof:lastmodified":1695886012,
     "wof:name":"Bayandelger",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/203/355/7/1092033557.geojson
+++ b/data/109/203/355/7/1092033557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256584,
-    "geom:area_square_m":2132902611.858957,
+    "geom:area_square_m":2132903116.518746,
     "geom:bbox":"107.954447,47.315902,108.546359,48.320998",
     "geom:latitude":47.757159,
     "geom:longitude":108.208065,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"MN.TO.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897866,
-    "wof:geomhash":"6f46257a67129430de8717117bbeff06",
+    "wof:geomhash":"344249b9cc88883499dbae4813ba4961",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1092033557,
-    "wof:lastmodified":1627522365,
+    "wof:lastmodified":1695886012,
     "wof:name":"Bayandelger",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/360/1/1092033601.geojson
+++ b/data/109/203/360/1/1092033601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.78009,
-    "geom:area_square_m":6287355134.255617,
+    "geom:area_square_m":6287355176.786438,
     "geom:bbox":"112.808791,48.789025,114.09812,49.97983",
     "geom:latitude":49.321071,
     "geom:longitude":113.420298,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.DD.BD",
         "wd:id":"Q3404398"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897867,
-    "wof:geomhash":"61c80d7bbbf0e0369593400c4725ad6c",
+    "wof:geomhash":"29d03884684f2b33581cef4c1ca86e7f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092033601,
-    "wof:lastmodified":1690939750,
+    "wof:lastmodified":1695886847,
     "wof:name":"Bayandun",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/363/5/1092033635.geojson
+++ b/data/109/203/363/5/1092033635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.405191,
-    "geom:area_square_m":3494039606.32682,
+    "geom:area_square_m":3494039606.326782,
     "geom:bbox":"102.8484241,45.3617979331,103.774343032,46.1308557876",
     "geom:latitude":45.782825,
     "geom:longitude":103.340578,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"MN.OH.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897869,
-    "wof:geomhash":"85f80d7fcde627016f20ef101e01c0ba",
+    "wof:geomhash":"e6d890ae7808c504eb90fe6b3217d303",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1092033635,
-    "wof:lastmodified":1566611705,
+    "wof:lastmodified":1695886845,
     "wof:name":"Bayangol",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/365/5/1092033655.geojson
+++ b/data/109/203/365/5/1092033655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.248637,
-    "geom:area_square_m":2017427806.86106,
+    "geom:area_square_m":2017427806.861356,
     "geom:bbox":"105.768387858,48.6468970794,106.582115879,49.2324142429",
     "geom:latitude":48.989799,
     "geom:longitude":106.182578,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"MN.SL.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897871,
-    "wof:geomhash":"4667616c8a6ad81722446e6069ab7e43",
+    "wof:geomhash":"755ebce7b92e99faebd8263b0dee8a8d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1092033655,
-    "wof:lastmodified":1566611702,
+    "wof:lastmodified":1695886845,
     "wof:name":"Bayangol",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/203/365/9/1092033659.geojson
+++ b/data/109/203/365/9/1092033659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002964,
-    "geom:area_square_m":24571417.370532,
+    "geom:area_square_m":24571417.370547,
     "geom:bbox":"106.785923101,47.8774591211,106.909516051,47.945469409",
     "geom:latitude":47.908736,
     "geom:longitude":106.844557,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"MN.UB.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897872,
-    "wof:geomhash":"fe2dfd13a8c219ce692e7bd0e52c1393",
+    "wof:geomhash":"536ea9e875acd66b1a2a633c5bf2555a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1092033659,
-    "wof:lastmodified":1566611702,
+    "wof:lastmodified":1695886845,
     "wof:name":"Bayangol",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/203/368/7/1092033687.geojson
+++ b/data/109/203/368/7/1092033687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.532897,
-    "geom:area_square_m":4685452082.505515,
+    "geom:area_square_m":4685452232.7267,
     "geom:bbox":"99.618643,43.986685,100.579476,45.074799",
     "geom:latitude":44.678185,
     "geom:longitude":100.043554,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.BH.BG",
         "wd:id":"Q2093444"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897874,
-    "wof:geomhash":"fa7a7cf63e2be96f4420e8bcb4399c4d",
+    "wof:geomhash":"efde3527d7e4be6e0f32602f14634c03",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092033687,
-    "wof:lastmodified":1690939746,
+    "wof:lastmodified":1695886012,
     "wof:name":"Bayangovi",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/372/7/1092033727.geojson
+++ b/data/109/203/372/7/1092033727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.367543,
-    "geom:area_square_m":3169331073.955397,
+    "geom:area_square_m":3169330924.474533,
     "geom:bbox":"107.637667,45.418326,108.565688,46.129448",
     "geom:latitude":45.78409,
     "geom:longitude":108.051719,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"MN.DU.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897876,
-    "wof:geomhash":"31fa47bbd88f2183248f02c4246db0d9",
+    "wof:geomhash":"338369e2aafc9dbb58f0d7c6fa0a30d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1092033727,
-    "wof:lastmodified":1627522365,
+    "wof:lastmodified":1695886012,
     "wof:name":"Bayanjargalan",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/377/1/1092033771.geojson
+++ b/data/109/203/377/1/1092033771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.338994,
-    "geom:area_square_m":2854625468.50702,
+    "geom:area_square_m":2854625373.516201,
     "geom:bbox":"107.807435,46.79035,108.845739,47.367137",
     "geom:latitude":47.076853,
     "geom:longitude":108.374637,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"MN.TO.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897877,
-    "wof:geomhash":"11a0577b11edda2bd9c84ba5b2552de1",
+    "wof:geomhash":"17fa8e7e717532303fbb028312ed8f52",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1092033771,
-    "wof:lastmodified":1627522365,
+    "wof:lastmodified":1695886013,
     "wof:name":"Bayanjargalan",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/381/1/1092033811.geojson
+++ b/data/109/203/381/1/1092033811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.345975,
-    "geom:area_square_m":11907100590.878616,
+    "geom:area_square_m":11907100156.115919,
     "geom:bbox":"100.068547,43.82883,101.742119,44.94602",
     "geom:latitude":44.320766,
     "geom:longitude":100.922833,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BH.BL",
         "wd:id":"Q2093431"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897879,
-    "wof:geomhash":"da22ccfe700676cf6f4d4ad048c16218",
+    "wof:geomhash":"3292dee17a229136440b0e13e5d528ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092033811,
-    "wof:lastmodified":1690939762,
+    "wof:lastmodified":1695886019,
     "wof:name":"Bayanlig",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/385/1/1092033851.geojson
+++ b/data/109/203/385/1/1092033851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301359,
-    "geom:area_square_m":2546174522.690221,
+    "geom:area_square_m":2546174622.200688,
     "geom:bbox":"109.255857,46.619178,110.108143,47.207763",
     "geom:latitude":46.898803,
     "geom:longitude":109.740291,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.HN.BM",
         "wd:id":"Q3396398"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897880,
-    "wof:geomhash":"ebb7c0fcaecc9c1558f60d12c1f980e3",
+    "wof:geomhash":"7320ed8e18e63c5d5c336a253db6f06a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092033851,
-    "wof:lastmodified":1690939742,
+    "wof:lastmodified":1695886846,
     "wof:name":"Bayanmo'nx",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/388/9/1092033889.geojson
+++ b/data/109/203/388/9/1092033889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.287004,
-    "geom:area_square_m":2332938034.414855,
+    "geom:area_square_m":2332938194.571922,
     "geom:bbox":"90.605559,48.617942,91.345907,49.29369",
     "geom:latitude":48.899667,
     "geom:longitude":90.928173,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.BO.BN",
         "wd:id":"Q2089537"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897882,
-    "wof:geomhash":"c4e26992ab2f1d6a86b220a7b47e6784",
+    "wof:geomhash":"19b398ada30bd1ae462ab9dca557bfbf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092033889,
-    "wof:lastmodified":1690939764,
+    "wof:lastmodified":1695886848,
     "wof:name":"Bayannuur",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/393/1/1092033931.geojson
+++ b/data/109/203/393/1/1092033931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122246,
-    "geom:area_square_m":1014282561.633581,
+    "geom:area_square_m":1014282580.855091,
     "geom:bbox":"104.276514,47.617156,104.745315,48.077459",
     "geom:latitude":47.855484,
     "geom:longitude":104.510329,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.BU.BN",
         "wd:id":"Q2606163"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897883,
-    "wof:geomhash":"3e77741e0dce43a68a8c2b6448628503",
+    "wof:geomhash":"fe57c377751cc1257f7769173bbe3d77",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092033931,
-    "wof:lastmodified":1690939749,
+    "wof:lastmodified":1695886013,
     "wof:name":"Bayannuur",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/203/395/7/1092033957.geojson
+++ b/data/109/203/395/7/1092033957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105691,
-    "geom:area_square_m":896286231.66827,
+    "geom:area_square_m":896286533.964501,
     "geom:bbox":"107.893595,46.504719,108.50285,46.830848",
     "geom:latitude":46.700133,
     "geom:longitude":108.279572,
@@ -92,9 +92,10 @@
         "hasc:id":"MN.GS.BT",
         "wd:id":"Q3410043"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897884,
-    "wof:geomhash":"b6bf9794cde1b26f474d1aba749134da",
+    "wof:geomhash":"82d83bcd951751d549a277bfa0e636de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092033957,
-    "wof:lastmodified":1690939745,
+    "wof:lastmodified":1695886013,
     "wof:name":"Bayantal",
     "wof:parent_id":85674779,
     "wof:placetype":"county",

--- a/data/109/203/399/5/1092033995.geojson
+++ b/data/109/203/399/5/1092033995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.547151,
-    "geom:area_square_m":4370407309.531939,
+    "geom:area_square_m":4370406974.849747,
     "geom:bbox":"95.44844,49.496124,97.131756,50.043986",
     "geom:latitude":49.76134,
     "geom:longitude":96.269497,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DZ.BT",
         "wd:id":"Q3402167"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897886,
-    "wof:geomhash":"ba93e1c74267261eb30bbaaaffd68f33",
+    "wof:geomhash":"7261b95cab5cfb5b69cf0198458bc090",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092033995,
-    "wof:lastmodified":1690939730,
+    "wof:lastmodified":1695886013,
     "wof:name":"Bayantes",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/403/9/1092034039.geojson
+++ b/data/109/203/403/9/1092034039.geojson
@@ -85,6 +85,7 @@
         "hasc:id":"MN.TO.BA",
         "wd:id":"Q3396325"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897887,
     "wof:geomhash":"49265e6d8cc6dbb5c29e8ca7e06d7959",
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092034039,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886011,
     "wof:name":"Bayan",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/407/5/1092034075.geojson
+++ b/data/109/203/407/5/1092034075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.045948,
-    "geom:area_square_m":8642655784.074036,
+    "geom:area_square_m":8642655893.574266,
     "geom:bbox":"113.66092,47.47,115.813796,48.618798",
     "geom:latitude":48.067671,
     "geom:longitude":114.974453,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.DD.BT",
         "wd:id":"Q3404293"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897889,
-    "wof:geomhash":"cf2480c73d5af7958b61a16df844b2a8",
+    "wof:geomhash":"8db2b897c1b18abd53e45881177045bd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092034075,
-    "wof:lastmodified":1690939737,
+    "wof:lastmodified":1695886846,
     "wof:name":"Bayantu'men",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/411/1/1092034111.geojson
+++ b/data/109/203/411/1/1092034111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.322009,
-    "geom:area_square_m":2593469958.919725,
+    "geom:area_square_m":2593470013.716167,
     "geom:bbox":"95.668561,49.161099,97.126061,49.553924",
     "geom:latitude":49.356752,
     "geom:longitude":96.29049,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DZ.BY",
         "wd:id":"Q3402255"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897890,
-    "wof:geomhash":"170d005ac3eece8be7f511f900ee46e3",
+    "wof:geomhash":"4279d3673c2ee231067f9fa220bca025",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092034111,
-    "wof:lastmodified":1690939752,
+    "wof:lastmodified":1695886013,
     "wof:name":"Bayanxairxan",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/426/7/1092034267.geojson
+++ b/data/109/203/426/7/1092034267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120056,
-    "geom:area_square_m":996590555.001242,
+    "geom:area_square_m":996590625.390339,
     "geom:bbox":"105.358783,47.544882,105.891716,48.077682",
     "geom:latitude":47.830597,
     "geom:longitude":105.596158,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.TO.BH",
         "wd:id":"Q3396622"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897892,
-    "wof:geomhash":"77d56d60c96b7c1cae0b56093d8c1569",
+    "wof:geomhash":"a8b3f592045e115cc3e721884ca345d8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092034267,
-    "wof:lastmodified":1690939750,
+    "wof:lastmodified":1695886013,
     "wof:name":"Bayanxangai",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/430/7/1092034307.geojson
+++ b/data/109/203/430/7/1092034307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007745,
-    "geom:area_square_m":66295446.583263,
+    "geom:area_square_m":66295487.71618,
     "geom:bbox":"100.656902,46.131424,100.748541,46.249933",
     "geom:latitude":46.18935,
     "geom:longitude":100.703921,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BH.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897899,
-    "wof:geomhash":"f27593bf3e75f9fda48ca19dd03e6707",
+    "wof:geomhash":"26a9edc8fe383a05c37a2ac1f6331247",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092034307,
-    "wof:lastmodified":1627522365,
+    "wof:lastmodified":1695886013,
     "wof:name":"Bayanxongor",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/433/7/1092034337.geojson
+++ b/data/109/203/433/7/1092034337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.718273,
-    "geom:area_square_m":6037049841.106245,
+    "geom:area_square_m":6037049210.57833,
     "geom:bbox":"110.043383,46.803932,111.815925,47.605868",
     "geom:latitude":47.177434,
     "geom:longitude":110.979571,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.HN.BH",
         "wd:id":"Q3410102"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897900,
-    "wof:geomhash":"567c042cf79c50995dacca6eb1da8fe2",
+    "wof:geomhash":"1b55466eb7acbfe66a88b1c55634d4a6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092034337,
-    "wof:lastmodified":1690939756,
+    "wof:lastmodified":1695886848,
     "wof:name":"Bayanxutag",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/437/5/1092034375.geojson
+++ b/data/109/203/437/5/1092034375.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1092034375,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886255,
     "wof:name":"Bayanzu'rx",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/203/442/3/1092034423.geojson
+++ b/data/109/203/442/3/1092034423.geojson
@@ -109,6 +109,7 @@
         "hasc:id":"MN.HG.BZ",
         "wd:id":"Q2607977"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897903,
     "wof:geomhash":"07a83ff052b3900359d71ab419589253",
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1092034423,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886847,
     "wof:name":"Bayanzu'rx",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/444/3/1092034443.geojson
+++ b/data/109/203/444/3/1092034443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.444775,
-    "geom:area_square_m":3839321674.759513,
+    "geom:area_square_m":3839321613.776022,
     "geom:bbox":"96.729175,45.334879,97.634639,46.094351",
     "geom:latitude":45.725489,
     "geom:longitude":97.173283,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.GA.BI",
         "wd:id":"Q2353177"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897905,
-    "wof:geomhash":"e966fe7df00443c82e38cc66e21060cb",
+    "wof:geomhash":"d66269e0c763e3d82d874a4e45e2b25b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092034443,
-    "wof:lastmodified":1690939751,
+    "wof:lastmodified":1695886013,
     "wof:name":"Biger",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/447/3/1092034473.geojson
+++ b/data/109/203/447/3/1092034473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.662571,
-    "geom:area_square_m":5418806017.353071,
+    "geom:area_square_m":5418805778.20073,
     "geom:bbox":"110.286506,47.893751,111.032314,49.255053",
     "geom:latitude":48.591649,
     "geom:longitude":110.643929,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.HN.BI",
         "wd:id":"Q3404134"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897906,
-    "wof:geomhash":"aec9bbb4848fea11cd0dc335bb09bdbd",
+    "wof:geomhash":"0a28bd0b833b3458999e279e96db3a1c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092034473,
-    "wof:lastmodified":1690939731,
+    "wof:lastmodified":1695886846,
     "wof:name":"Binder",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/450/5/1092034505.geojson
+++ b/data/109/203/450/5/1092034505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.354053,
-    "geom:area_square_m":3027336777.908894,
+    "geom:area_square_m":3027336764.786787,
     "geom:bbox":"99.25416,45.881175,100.036914,46.611586",
     "geom:latitude":46.250881,
     "geom:longitude":99.586029,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BH.BM",
         "wd:id":"Q2093539"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897908,
-    "wof:geomhash":"6a97dfcc7f212dcc114060cd5b85b41d",
+    "wof:geomhash":"bfce3eb99e29f69d1d11fb210bec2b3b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092034505,
-    "wof:lastmodified":1690939757,
+    "wof:lastmodified":1695886013,
     "wof:name":"Bo'mbogor",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/452/9/1092034529.geojson
+++ b/data/109/203/452/9/1092034529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.477553,
-    "geom:area_square_m":3808524321.648535,
+    "geom:area_square_m":3808524531.436281,
     "geom:bbox":"89.999186,49.424032,91.492108,50.200675",
     "geom:latitude":49.836987,
     "geom:longitude":90.624115,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.UV.BO",
         "wd:id":"Q3402203"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897909,
-    "wof:geomhash":"8b9cc578332e2c79bebd9c88fc7acb1e",
+    "wof:geomhash":"91933139037fe926113319c6b28e04f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092034529,
-    "wof:lastmodified":1690939736,
+    "wof:lastmodified":1695886014,
     "wof:name":"Bo'xmoron",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/203/456/3/1092034563.geojson
+++ b/data/109/203/456/3/1092034563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.455176,
-    "geom:area_square_m":3970692809.32793,
+    "geom:area_square_m":3970692809.328144,
     "geom:bbox":"100.236186644,44.7818752806,101.555585884,45.6340140567",
     "geom:latitude":45.131172,
     "geom:longitude":100.842888,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BH.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897911,
-    "wof:geomhash":"03cd8aef5e6c8e6559734a60e3a2dc2c",
+    "wof:geomhash":"a677179fcbeac2b5f82a594c815afcdd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092034563,
-    "wof:lastmodified":1566611734,
+    "wof:lastmodified":1695886847,
     "wof:name":"Bogd",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/460/1/1092034601.geojson
+++ b/data/109/203/460/1/1092034601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.134287,
-    "geom:area_square_m":9992291935.976082,
+    "geom:area_square_m":9992291935.9753,
     "geom:bbox":"101.499133946,44.0422150109,103.249437469,45.026507996",
     "geom:latitude":44.566715,
     "geom:longitude":102.304637,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"MN.OH.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897912,
-    "wof:geomhash":"8c0d917d519e4335330798b150c8b0b4",
+    "wof:geomhash":"0a60d43a1639039b6ae038ad3f7d041a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092034601,
-    "wof:lastmodified":1566611734,
+    "wof:lastmodified":1695886847,
     "wof:name":"Bogd",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/463/7/1092034637.geojson
+++ b/data/109/203/463/7/1092034637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139964,
-    "geom:area_square_m":1146880422.988572,
+    "geom:area_square_m":1146879946.665115,
     "geom:bbox":"105.988054,48.27816,106.534148,48.690847",
     "geom:latitude":48.495604,
     "geom:longitude":106.254213,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.TO.BR",
         "wd:id":"Q3396355"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897914,
-    "wof:geomhash":"85d07fef81d75808bffedf9a8c0ee71f",
+    "wof:geomhash":"028b1b7ee182bf6f183a05192831ec7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092034637,
-    "wof:lastmodified":1690939736,
+    "wof:lastmodified":1695886014,
     "wof:name":"Bornuur",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/467/1/1092034671.geojson
+++ b/data/109/203/467/1/1092034671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.30504,
-    "geom:area_square_m":2569570051.750676,
+    "geom:area_square_m":2569570016.816226,
     "geom:bbox":"103.369481,46.83609,104.360984,47.316257",
     "geom:latitude":47.059023,
     "geom:longitude":103.874754,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.OH.BR",
         "wd:id":"Q2353266"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897915,
-    "wof:geomhash":"3ba3d3a751f0b0636709c9ef80ccc964",
+    "wof:geomhash":"32aa268fdafc42cef1bad80583acaef8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092034671,
-    "wof:lastmodified":1690939754,
+    "wof:lastmodified":1695886014,
     "wof:name":"Bu'rd",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/470/7/1092034707.geojson
+++ b/data/109/203/470/7/1092034707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.422383,
-    "geom:area_square_m":3468785274.502752,
+    "geom:area_square_m":3468785349.725522,
     "geom:bbox":"103.638218,47.935631,104.558005,48.741701",
     "geom:latitude":48.382161,
     "geom:longitude":104.091011,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BU.BR",
         "wd:id":"Q2605763"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897917,
-    "wof:geomhash":"4c31f1dfbeeb61585b0ba4a86992166b",
+    "wof:geomhash":"f0aa179da0db7921b464d2287f65613d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092034707,
-    "wof:lastmodified":1690939733,
+    "wof:lastmodified":1695886014,
     "wof:name":"Bu'regxangai",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/203/474/5/1092034745.geojson
+++ b/data/109/203/474/5/1092034745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.444213,
-    "geom:area_square_m":3755951273.108742,
+    "geom:area_square_m":3755951368.66086,
     "geom:bbox":"104.650025,46.461981,105.691005,47.223806",
     "geom:latitude":46.858654,
     "geom:longitude":105.173592,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.TO.BU",
         "wd:id":"Q3396586"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897918,
-    "wof:geomhash":"91c4a24a716478d419ecfb7469872608",
+    "wof:geomhash":"18dc90397f7633fe09affecd3ea1a1a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092034745,
-    "wof:lastmodified":1690939753,
+    "wof:lastmodified":1695886014,
     "wof:name":"Bu'ren",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/476/5/1092034765.geojson
+++ b/data/109/203/476/5/1092034765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.472143,
-    "geom:area_square_m":3794738909.024424,
+    "geom:area_square_m":3794738891.515877,
     "geom:bbox":"98.803737,49.133993,100.527585,49.896313",
     "geom:latitude":49.458919,
     "geom:longitude":99.575042,
@@ -125,9 +125,10 @@
         "hasc:id":"MN.HG.BU",
         "wd:id":"Q2607968"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897920,
-    "wof:geomhash":"0dcf205e36515bf4ddf2cea54dad29a1",
+    "wof:geomhash":"004d280de897bdbadaf0dec7512c2657",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1092034765,
-    "wof:lastmodified":1690939731,
+    "wof:lastmodified":1695886846,
     "wof:name":"Bu'rentogtox",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/480/1/1092034801.geojson
+++ b/data/109/203/480/1/1092034801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.249965,
-    "geom:area_square_m":2027502416.58429,
+    "geom:area_square_m":2027502819.062838,
     "geom:bbox":"89.451786,48.578007,90.461314,49.440015",
     "geom:latitude":49.006546,
     "geom:longitude":89.992109,
@@ -116,9 +116,10 @@
         "hasc:id":"MN.BO.BG",
         "wd:id":"Q2093479"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897921,
-    "wof:geomhash":"772add03718bac072332f4643c802dd7",
+    "wof:geomhash":"6b0e0cea97338f71e7c32619d505e10f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1092034801,
-    "wof:lastmodified":1690939754,
+    "wof:lastmodified":1695886847,
     "wof:name":"Bugat",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/483/5/1092034835.geojson
+++ b/data/109/203/483/5/1092034835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.393508,
-    "geom:area_square_m":3186060267.734704,
+    "geom:area_square_m":3186059681.094832,
     "geom:bbox":"102.95728,48.825225,104.029558,49.384597",
     "geom:latitude":49.096392,
     "geom:longitude":103.44054,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.BU.BG",
         "wd:id":"Q2605809"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897923,
-    "wof:geomhash":"fded7b18f14b4a0a397975240da3b2bd",
+    "wof:geomhash":"e4aa719d201d0a599d0d5fcecaa3dde3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092034835,
-    "wof:lastmodified":1690939733,
+    "wof:lastmodified":1695886014,
     "wof:name":"Bugat",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/203/486/1/1092034861.geojson
+++ b/data/109/203/486/1/1092034861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.141935,
-    "geom:area_square_m":9944288063.534044,
+    "geom:area_square_m":9944288089.243063,
     "geom:bbox":"93.395123,44.510091,94.823927,45.876923",
     "geom:latitude":45.229744,
     "geom:longitude":94.132281,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.GA.BG",
         "wd:id":"Q2353218"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897924,
-    "wof:geomhash":"3421b309584a8ef872e8367edfef84d0",
+    "wof:geomhash":"f756e2e4eb0568f3389fcf60cb453461",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092034861,
-    "wof:lastmodified":1690939752,
+    "wof:lastmodified":1695886014,
     "wof:name":"Bugat",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/489/3/1092034893.geojson
+++ b/data/109/203/489/3/1092034893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.381565,
-    "geom:area_square_m":3206889331.606251,
+    "geom:area_square_m":3206888775.703108,
     "geom:bbox":"101.124428,46.766265,102.118043,47.691489",
     "geom:latitude":47.179698,
     "geom:longitude":101.689177,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"MN.AR.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897926,
-    "wof:geomhash":"a5db98b61b73654f7a68588374eadbd6",
+    "wof:geomhash":"7a74649080b84d7d74dd6ad37f24366b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092034893,
-    "wof:lastmodified":1636504688,
+    "wof:lastmodified":1695886158,
     "wof:name":"Bulgan",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/492/5/1092034925.geojson
+++ b/data/109/203/492/5/1092034925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.586481,
-    "geom:area_square_m":4944325343.770149,
+    "geom:area_square_m":4944325162.459545,
     "geom:bbox":"90.486842,46.550602,91.921412,47.521683",
     "geom:latitude":47.015718,
     "geom:longitude":91.17725,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BO.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897927,
-    "wof:geomhash":"491ee4e4ac2e7c936b13d994a02945c7",
+    "wof:geomhash":"d001cf483cb4a3af67ac711f119cc831",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092034925,
-    "wof:lastmodified":1636504688,
+    "wof:lastmodified":1695886158,
     "wof:name":"Bulgan",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/495/9/1092034959.geojson
+++ b/data/109/203/495/9/1092034959.geojson
@@ -81,6 +81,7 @@
     "wof:concordances":{
         "hasc:id":"MN.BU.OR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897929,
     "wof:geomhash":"11065221b91c7edb8e67390e8431e81d",
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092034959,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886158,
     "wof:name":"Bulgan",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/203/498/1/1092034981.geojson
+++ b/data/109/203/498/1/1092034981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.848434,
-    "geom:area_square_m":7065220871.028399,
+    "geom:area_square_m":7065221010.769159,
     "geom:bbox":"113.375419,47.149319,114.921669,48.054441",
     "geom:latitude":47.66554,
     "geom:longitude":114.206718,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.DD.BG",
         "wd:id":"Q3410062"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897930,
-    "wof:geomhash":"4404ae6feccd2343e7334e70033e0b97",
+    "wof:geomhash":"94d3703d569f43c8e73ce70e15ee1d79",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092034981,
-    "wof:lastmodified":1690939739,
+    "wof:lastmodified":1695886158,
     "wof:name":"Bulgan",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/501/7/1092035017.geojson
+++ b/data/109/203/501/7/1092035017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.83971,
-    "geom:area_square_m":7443955618.826011,
+    "geom:area_square_m":7443956189.063255,
     "geom:bbox":"102.855012,43.75253,104.129786,44.835833",
     "geom:latitude":44.198323,
     "geom:longitude":103.470249,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"MN.OG.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897932,
-    "wof:geomhash":"3d40ca6c2cb35ddb7a11bc56db6652d3",
+    "wof:geomhash":"997cbc780326b64af1f2d73266f37ff7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092035017,
-    "wof:lastmodified":1636504688,
+    "wof:lastmodified":1695886158,
     "wof:name":"Bulgan",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/504/7/1092035047.geojson
+++ b/data/109/203/504/7/1092035047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.938868,
-    "geom:area_square_m":8077089340.900545,
+    "geom:area_square_m":8077089232.109901,
     "geom:bbox":"90.665146,45.130237,91.763466,46.717984",
     "geom:latitude":45.912145,
     "geom:longitude":91.196914,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HD.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897933,
-    "wof:geomhash":"d3306a364ddabbd7e5c45768468183f9",
+    "wof:geomhash":"f5a3d0e53f8a99f154391b1e4494b792",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092035047,
-    "wof:lastmodified":1636504687,
+    "wof:lastmodified":1695886158,
     "wof:name":"Bulgan",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/506/9/1092035069.geojson
+++ b/data/109/203/506/9/1092035069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.627952,
-    "geom:area_square_m":5376554977.05946,
+    "geom:area_square_m":5376555303.215399,
     "geom:bbox":"98.182643,45.754877,99.380327,46.660893",
     "geom:latitude":46.176795,
     "geom:longitude":98.820429,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.BH.BU",
         "wd:id":"Q2089556"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897935,
-    "wof:geomhash":"9e8ea8ee359863ea34a7bb4cf9a85064",
+    "wof:geomhash":"bb63fd6dec73078f56f7174ba2f5954c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092035069,
-    "wof:lastmodified":1690939746,
+    "wof:lastmodified":1695886014,
     "wof:name":"Buucagaan",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/510/1/1092035101.geojson
+++ b/data/109/203/510/1/1092035101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.22337,
-    "geom:area_square_m":1826977564.628042,
+    "geom:area_square_m":1826977781.196262,
     "geom:bbox":"89.308046,48.300732,90.084102,48.879841",
     "geom:latitude":48.588206,
     "geom:longitude":89.765504,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BO.BY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897936,
-    "wof:geomhash":"1c1f1a1f2c0c821437f479380cd5f575",
+    "wof:geomhash":"78aec20d867c1b71b28b3588aceed0e3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1092035101,
-    "wof:lastmodified":1627522367,
+    "wof:lastmodified":1695886015,
     "wof:name":"Buyant",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/513/9/1092035139.geojson
+++ b/data/109/203/513/9/1092035139.geojson
@@ -63,6 +63,7 @@
     "wof:concordances":{
         "hasc:id":"MN.HD.BY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897938,
     "wof:geomhash":"537e9ee98151380be19c39f4cfbe220b",
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1092035139,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886270,
     "wof:name":"Buyant",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/517/5/1092035175.geojson
+++ b/data/109/203/517/5/1092035175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.786585,
-    "geom:area_square_m":6453845738.242027,
+    "geom:area_square_m":6453845709.163239,
     "geom:bbox":"112.399821,48.008975,113.858084,48.846942",
     "geom:latitude":48.428708,
     "geom:longitude":113.22926,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DD.TO",
         "wd:id":"Q3404226"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897939,
-    "wof:geomhash":"3ff2193ac7f42851ca82b158e89348f2",
+    "wof:geomhash":"f3eed2de5856f7ac900ac3a628b4ffef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092035175,
-    "wof:lastmodified":1690939740,
+    "wof:lastmodified":1695886026,
     "wof:name":"Cagaan-Ovoo",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/520/3/1092035203.geojson
+++ b/data/109/203/520/3/1092035203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.121746,
-    "geom:area_square_m":8744436326.331007,
+    "geom:area_square_m":8744436671.968811,
     "geom:bbox":"100.948478,50.267586,102.344333,51.547559",
     "geom:latitude":50.917566,
     "geom:longitude":101.632723,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.HG.TR",
         "wd:id":"Q2607931"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897941,
-    "wof:geomhash":"19919b6955b64f2f744264f48f7314c1",
+    "wof:geomhash":"d59e24b46082faa617fdbbcdd6ee2731",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092035203,
-    "wof:lastmodified":1690939743,
+    "wof:lastmodified":1695886846,
     "wof:name":"Cagaan-U'ur",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/523/7/1092035237.geojson
+++ b/data/109/203/523/7/1092035237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.721131,
-    "geom:area_square_m":5784424540.681587,
+    "geom:area_square_m":5784424487.102039,
     "geom:bbox":"98.008446,49.019486,99.213007,50.01575",
     "geom:latitude":49.555807,
     "geom:longitude":98.57547,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.HG.TL",
         "wd:id":"Q2607936"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897942,
-    "wof:geomhash":"7e4eedbbc611231d07c2610a791a7dad",
+    "wof:geomhash":"3d954847109000619410310ed93a9dd2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092035237,
-    "wof:lastmodified":1690939762,
+    "wof:lastmodified":1695886848,
     "wof:name":"Cagaan-Uul",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/528/1/1092035281.geojson
+++ b/data/109/203/528/1/1092035281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307319,
-    "geom:area_square_m":2585916306.409132,
+    "geom:area_square_m":2585916252.151091,
     "geom:bbox":"96.237852,46.839971,97.17605,47.413481",
     "geom:latitude":47.117723,
     "geom:longitude":96.679004,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DZ.TC",
         "wd:id":"Q3404155"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897944,
-    "wof:geomhash":"754a9168c80effb60690f3de90fc5ade",
+    "wof:geomhash":"8e3c5d5e136b9a8c29c345c3ebbc0f81",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092035281,
-    "wof:lastmodified":1690939741,
+    "wof:lastmodified":1695886027,
     "wof:name":"Cagaanchuluut",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/531/1/1092035311.geojson
+++ b/data/109/203/531/1/1092035311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404958,
-    "geom:area_square_m":3454260028.867064,
+    "geom:area_square_m":3454260752.922152,
     "geom:bbox":"107.137883,46.02637,108.304155,46.779329",
     "geom:latitude":46.382856,
     "geom:longitude":107.858467,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DU.TD",
         "wd:id":"Q3410085"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897945,
-    "wof:geomhash":"bfd4c52a65e18c4957e7dd0f50d30d81",
+    "wof:geomhash":"69f7ec8d6028a9be321301d42a7b54e6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092035311,
-    "wof:lastmodified":1690939749,
+    "wof:lastmodified":1695886027,
     "wof:name":"Cagaandelger",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/535/5/1092035355.geojson
+++ b/data/109/203/535/5/1092035355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.475827,
-    "geom:area_square_m":3780213305.78303,
+    "geom:area_square_m":3780213306.642183,
     "geom:bbox":"104.526147,49.676057,106.129804,50.290507",
     "geom:latitude":50.022095,
     "geom:longitude":105.224025,
@@ -89,9 +89,10 @@
         "hasc:id":"MN.SL.TN",
         "wd:id":"Q2748174"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897946,
-    "wof:geomhash":"c9796e0da851cfe54f9249dd00d45696",
+    "wof:geomhash":"6937b53c3e50b910460d8bd6d88e2580",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1092035355,
-    "wof:lastmodified":1690939730,
+    "wof:lastmodified":1695886846,
     "wof:name":"Cagaannuur",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/203/539/5/1092035395.geojson
+++ b/data/109/203/539/5/1092035395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.731272,
-    "geom:area_square_m":5608438478.368448,
+    "geom:area_square_m":5608438808.838678,
     "geom:bbox":"98.219276,51.131731,99.871532,52.148696",
     "geom:latitude":51.665772,
     "geom:longitude":99.012056,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.HG.TN",
         "wd:id":"Q2607710"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897948,
-    "wof:geomhash":"90050fa6dc117956e0c2821a838d4059",
+    "wof:geomhash":"9302e45d887a5928e612f42d448697f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092035395,
-    "wof:lastmodified":1690939745,
+    "wof:lastmodified":1695886847,
     "wof:name":"Cagaannuur",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/543/1/1092035431.geojson
+++ b/data/109/203/543/1/1092035431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.501771,
-    "geom:area_square_m":4061026826.059798,
+    "geom:area_square_m":4061026460.707594,
     "geom:bbox":"93.710789,48.717358,94.655236,49.634376",
     "geom:latitude":49.115627,
     "geom:longitude":94.215653,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.UV.TH",
         "wd:id":"Q3403800"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897949,
-    "wof:geomhash":"bb5dcd185ba34a67adb888599e026bf1",
+    "wof:geomhash":"280b2207b0d133cb69bd5ad43b873d51",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092035431,
-    "wof:lastmodified":1690939742,
+    "wof:lastmodified":1695886015,
     "wof:name":"Cagaanxairxan",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/203/547/3/1092035473.geojson
+++ b/data/109/203/547/3/1092035473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.313905,
-    "geom:area_square_m":2625651668.789577,
+    "geom:area_square_m":2625651896.0943,
     "geom:bbox":"96.08322,47.199116,97.529675,47.6292",
     "geom:latitude":47.432822,
     "geom:longitude":96.788496,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.DZ.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897951,
-    "wof:geomhash":"b0b7d293bab86d44fbcc9c29921b794a",
+    "wof:geomhash":"f0e53cd5e79a732f784bcac6cdb34e4a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092035473,
-    "wof:lastmodified":1627522367,
+    "wof:lastmodified":1695886015,
     "wof:name":"Cagaanxairxan",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/551/7/1092035517.geojson
+++ b/data/109/203/551/7/1092035517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.397342,
-    "geom:area_square_m":3289997279.516418,
+    "geom:area_square_m":3289997223.010496,
     "geom:bbox":"98.171942,47.641617,99.19992,48.309922",
     "geom:latitude":47.961916,
     "geom:longitude":98.660187,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.AR.TK",
         "wd:id":"Q2089887"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897952,
-    "wof:geomhash":"7dd1b842474998dbbf1aefcafc3449a4",
+    "wof:geomhash":"8dd34c0cc85b70cdac74b648b7dd8880",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092035517,
-    "wof:lastmodified":1690939725,
+    "wof:lastmodified":1695886027,
     "wof:name":"Caxir",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/555/9/1092035559.geojson
+++ b/data/109/203/555/9/1092035559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.408841,
-    "geom:area_square_m":3488944804.906132,
+    "geom:area_square_m":3488944807.596988,
     "geom:bbox":"92.839292,45.9076,93.641869,46.773777",
     "geom:latitude":46.358344,
     "geom:longitude":93.261853,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.HD.TS",
         "wd:id":"Q3404189"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897954,
-    "wof:geomhash":"bcfd74b57e4b61a976de3161d1983e6c",
+    "wof:geomhash":"cee3cc67060190248fb5d7e6057dc706",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092035559,
-    "wof:lastmodified":1690939746,
+    "wof:lastmodified":1695886847,
     "wof:name":"Ceceg",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/558/7/1092035587.geojson
+++ b/data/109/203/558/7/1092035587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.297251,
-    "geom:area_square_m":2431658531.293417,
+    "geom:area_square_m":2431658448.475113,
     "geom:bbox":"95.351196,48.317274,96.348508,48.836278",
     "geom:latitude":48.57987,
     "geom:longitude":95.861892,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.DZ.TU",
         "wd:id":"Q3403773"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897955,
-    "wof:geomhash":"0a6b5f4fb5a7f7fd0618861836d3b525",
+    "wof:geomhash":"25cee5a79000c275cb605cd0c4bd2f08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092035587,
-    "wof:lastmodified":1690939727,
+    "wof:lastmodified":1695886027,
     "wof:name":"Cecen-Uul",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/563/1/1092035631.geojson
+++ b/data/109/203/563/1/1092035631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.308217,
-    "geom:area_square_m":2503671834.982192,
+    "geom:area_square_m":2503671891.640795,
     "geom:bbox":"100.419473,48.695478,101.813932,49.222039",
     "geom:latitude":48.933593,
     "geom:longitude":101.143085,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.AR.TT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897957,
-    "wof:geomhash":"efd658ebf3e3087b84412d21ad2a7b80",
+    "wof:geomhash":"71fee5833b1aaaf9d09338fe203e9291",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092035631,
-    "wof:lastmodified":1627522367,
+    "wof:lastmodified":1695886015,
     "wof:name":"Cecerleg",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/566/9/1092035669.geojson
+++ b/data/109/203/566/9/1092035669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.916545,
-    "geom:area_square_m":7365472879.137969,
+    "geom:area_square_m":7365473053.887023,
     "geom:bbox":"96.838046,48.973549,98.701555,50.035246",
     "geom:latitude":49.465574,
     "geom:longitude":97.681896,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HG.TT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897958,
-    "wof:geomhash":"27693ff577b243a3ea407cb27be40419",
+    "wof:geomhash":"098a7a64ec09643f3f746f0b7f5bc6b7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092035669,
-    "wof:lastmodified":1627522367,
+    "wof:lastmodified":1695886015,
     "wof:name":"Cecerleg",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/569/9/1092035699.geojson
+++ b/data/109/203/569/9/1092035699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.647851,
-    "geom:area_square_m":5617639625.537799,
+    "geom:area_square_m":5617639890.915531,
     "geom:bbox":"94.954844,45.030834,96.282182,45.814635",
     "geom:latitude":45.471738,
     "geom:longitude":95.67783,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.GA.TL",
         "wd:id":"Q3404143"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897960,
-    "wof:geomhash":"7342fe468479fd44339c74221e0732b9",
+    "wof:geomhash":"1a9d39290b959d02eb649eaeb750c115",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092035699,
-    "wof:lastmodified":1690939726,
+    "wof:lastmodified":1695886027,
     "wof:name":"Ceel",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/574/1/1092035741.geojson
+++ b/data/109/203/574/1/1092035741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198357,
-    "geom:area_square_m":1627563024.640574,
+    "geom:area_square_m":1627562834.256148,
     "geom:bbox":"104.93482,48.142683,105.758351,48.667413",
     "geom:latitude":48.426958,
     "geom:longitude":105.275089,
@@ -92,9 +92,10 @@
         "hasc:id":"MN.TO.TS",
         "wd:id":"Q3396704"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897961,
-    "wof:geomhash":"08c3596f6a333cdb212b4bb42e8420e9",
+    "wof:geomhash":"b9b5614cac2aabfd80794a1f03df7439",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092035741,
-    "wof:lastmodified":1690939745,
+    "wof:lastmodified":1695886027,
     "wof:name":"Ceel",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/578/5/1092035785.geojson
+++ b/data/109/203/578/5/1092035785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.790902,
-    "geom:area_square_m":6435742018.07341,
+    "geom:area_square_m":6435741834.341399,
     "geom:bbox":"87.73762,48.360159,89.331448,49.182676",
     "geom:latitude":48.846553,
     "geom:longitude":88.517621,
@@ -131,9 +131,10 @@
         "hasc:id":"MN.BO.TS",
         "wd:id":"Q2667633"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897963,
-    "wof:geomhash":"5e03ccbb75f70665fc1233427718feb0",
+    "wof:geomhash":"898a52184f11a290887c16bd7e618bf5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1092035785,
-    "wof:lastmodified":1690939760,
+    "wof:lastmodified":1695886848,
     "wof:name":"Cengel",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/582/3/1092035823.geojson
+++ b/data/109/203/582/3/1092035823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.375999,
-    "geom:area_square_m":3161040536.495788,
+    "geom:area_square_m":3161040332.387682,
     "geom:bbox":"100.655102,46.832882,101.625979,47.550234",
     "geom:latitude":47.164296,
     "geom:longitude":101.13333,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.AR.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897964,
-    "wof:geomhash":"1f995fc7858d40b653d40a35550cacb7",
+    "wof:geomhash":"c5c9dc41aaae5a1b506fb203f276749e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092035823,
-    "wof:lastmodified":1627522367,
+    "wof:lastmodified":1695886015,
     "wof:name":"Cenxer",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/585/9/1092035859.geojson
+++ b/data/109/203/585/9/1092035859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.383511,
-    "geom:area_square_m":3183385015.046121,
+    "geom:area_square_m":3183384368.074433,
     "geom:bbox":"108.408157,47.562902,109.332127,48.252418",
     "geom:latitude":47.833028,
     "geom:longitude":108.911944,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.HN.TS",
         "wd:id":"Q3404259"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897966,
-    "wof:geomhash":"1adde254617a54de4ecc7a07166d7432",
+    "wof:geomhash":"b6355808f90bd92b67ec69b2a171a395",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092035859,
-    "wof:lastmodified":1690939760,
+    "wof:lastmodified":1695886848,
     "wof:name":"Cenxermandal",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/590/1/1092035901.geojson
+++ b/data/109/203/590/1/1092035901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.565269,
-    "geom:area_square_m":4446323685.042424,
+    "geom:area_square_m":4446323316.7909,
     "geom:bbox":"100.389396,50.059924,101.300805,50.949934",
     "geom:latitude":50.495876,
     "geom:longitude":100.84704,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.HG.CO",
         "wd:id":"Q2607753"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897967,
-    "wof:geomhash":"5c1ae3a73d0943e60daee53d368ce0cd",
+    "wof:geomhash":"b3028aeed003c9cb75c8ef0e72e22b5a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092035901,
-    "wof:lastmodified":1690939747,
+    "wof:lastmodified":1695886847,
     "wof:name":"Chandmani-O'ndor",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/594/1/1092035941.geojson
+++ b/data/109/203/594/1/1092035941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.531743,
-    "geom:area_square_m":4610273302.606404,
+    "geom:area_square_m":4610273352.860121,
     "geom:bbox":"97.484783,45.040169,98.490249,45.832905",
     "geom:latitude":45.478686,
     "geom:longitude":98.01083,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.GA.CH",
         "wd:id":"Q3410073"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897969,
-    "wof:geomhash":"a4e73ad34c4d94d8d0b0829bf5089626",
+    "wof:geomhash":"897fc7537bc1f443348ba2ea88317265",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092035941,
-    "wof:lastmodified":1690939726,
+    "wof:lastmodified":1695886015,
     "wof:name":"Chandmani",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/597/3/1092035973.geojson
+++ b/data/109/203/597/3/1092035973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.729331,
-    "geom:area_square_m":6063291157.522852,
+    "geom:area_square_m":6063290297.9445,
     "geom:bbox":"92.123118,47.280292,93.623953,48.218903",
     "geom:latitude":47.752468,
     "geom:longitude":92.982359,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.HD.CH",
         "wd:id":"Q3300801"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897971,
-    "wof:geomhash":"92c1875f18181cf0b65e2d6e92928e74",
+    "wof:geomhash":"faa9cd403f13189aaeb29c2661f833ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092035973,
-    "wof:lastmodified":1690939748,
+    "wof:lastmodified":1695886847,
     "wof:name":"Chandmani",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/601/7/1092036017.geojson
+++ b/data/109/203/601/7/1092036017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010898,
-    "geom:area_square_m":90122659.652527,
+    "geom:area_square_m":90122582.555065,
     "geom:bbox":"106.831531,47.91611,106.931145,48.138586",
     "geom:latitude":48.026869,
     "geom:longitude":106.882561,
@@ -110,9 +110,10 @@
         "hasc:id":"MN.UB.CH",
         "wd:id":"Q2637612"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897972,
-    "wof:geomhash":"623d93c40b69956885e9f5a25d85b3a7",
+    "wof:geomhash":"e4cf0703febeb00eb600b4c574ea4577",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1092036017,
-    "wof:lastmodified":1690939757,
+    "wof:lastmodified":1695886015,
     "wof:name":"Chingeltei",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/203/605/7/1092036057.geojson
+++ b/data/109/203/605/7/1092036057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.237662,
-    "geom:area_square_m":10054397620.202608,
+    "geom:area_square_m":10054397263.444218,
     "geom:bbox":"114.470808,48.134712,116.518134,49.652248",
     "geom:latitude":48.929054,
     "geom:longitude":115.491302,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DD.CB",
         "wd:id":"Q3404349"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897973,
-    "wof:geomhash":"338d2b1fbb72a007f735f4cf8aa42971",
+    "wof:geomhash":"a4e0f397ea4b8af23c0e01007aae81f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092036057,
-    "wof:lastmodified":1690939736,
+    "wof:lastmodified":1695886016,
     "wof:name":"Choibalsan",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/607/9/1092036079.geojson
+++ b/data/109/203/607/9/1092036079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.80165,
-    "geom:area_square_m":6393739468.299227,
+    "geom:area_square_m":6393739385.877744,
     "geom:bbox":"114.439666,49.51991,116.714072,50.233912",
     "geom:latitude":49.833165,
     "geom:longitude":115.57267,
@@ -125,9 +125,10 @@
         "hasc:id":"MN.DD.CH",
         "wd:id":"Q1771883"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897975,
-    "wof:geomhash":"2295f0fe8e18591f2ed25706c8bd8ae3",
+    "wof:geomhash":"0ebb78eb76e120f6e16fcb64ea7f9313",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1092036079,
-    "wof:lastmodified":1690939758,
+    "wof:lastmodified":1695886848,
     "wof:name":"Chuluunxoroot",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/611/9/1092036119.geojson
+++ b/data/109/203/611/9/1092036119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.470173,
-    "geom:area_square_m":3927015570.50218,
+    "geom:area_square_m":3927016082.335949,
     "geom:bbox":"99.685462,47.094226,100.644151,47.901504",
     "geom:latitude":47.509302,
     "geom:longitude":100.172331,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.AR.CH",
         "wd:id":"Q3410278"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897976,
-    "wof:geomhash":"60c7e5f9ff12a63a3eeffbd4fc463c86",
+    "wof:geomhash":"c87d08163ae6b3d7659f1aee7f83cf7f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092036119,
-    "wof:lastmodified":1690939735,
+    "wof:lastmodified":1695886016,
     "wof:name":"Chuluut",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/616/7/1092036167.geojson
+++ b/data/109/203/616/7/1092036167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.815524,
-    "geom:area_square_m":7281682039.311141,
+    "geom:area_square_m":7281681924.699512,
     "geom:bbox":"105.255314,43.363152,106.523362,44.245529",
     "geom:latitude":43.7719,
     "geom:longitude":105.878907,
@@ -113,9 +113,10 @@
         "hasc:id":"MN.OG.TT",
         "wd:id":"Q902868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897978,
-    "wof:geomhash":"21635de92b0596938b984825f44f0764",
+    "wof:geomhash":"695b6d285964f3055babb40496d3e4f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1092036167,
-    "wof:lastmodified":1690939735,
+    "wof:lastmodified":1695886016,
     "wof:name":"Cogt-Cecii",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/620/3/1092036203.geojson
+++ b/data/109/203/620/3/1092036203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.741445,
-    "geom:area_square_m":6556780893.023735,
+    "geom:area_square_m":6556780858.990539,
     "geom:bbox":"104.476363,43.957848,105.825608,44.71479",
     "geom:latitude":44.342347,
     "geom:longitude":105.116084,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.OG.TO",
         "wd:id":"Q3403847"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897979,
-    "wof:geomhash":"638408d41ba4602b410b2ce0c87eb0aa",
+    "wof:geomhash":"b8e0ede72b725a970902120d928b04c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092036203,
-    "wof:lastmodified":1690939734,
+    "wof:lastmodified":1695886028,
     "wof:name":"Cogt-Ovoo",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/624/1/1092036241.geojson
+++ b/data/109/203/624/1/1092036241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.890899,
-    "geom:area_square_m":16673373116.070469,
+    "geom:area_square_m":16673372759.455961,
     "geom:bbox":"96.010402,42.724006,97.325756,45.722662",
     "geom:latitude":44.506489,
     "geom:longitude":96.607442,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.GA.TS",
         "wd:id":"Q3410067"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897981,
-    "wof:geomhash":"f8c03e33965d228629a93788ca85b9ad",
+    "wof:geomhash":"7aa3546f57035e92ae6924e56896de67",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092036241,
-    "wof:lastmodified":1690939752,
+    "wof:lastmodified":1695886028,
     "wof:name":"Cogt",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/628/3/1092036283.geojson
+++ b/data/109/203/628/3/1092036283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.604689,
-    "geom:area_square_m":4896473028.684554,
+    "geom:area_square_m":4896472843.698845,
     "geom:bbox":"110.742406,48.690038,112.291941,49.414212",
     "geom:latitude":49.090545,
     "geom:longitude":111.511189,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.HN.DD",
         "wd:id":"Q2223424"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897982,
-    "wof:geomhash":"3de73ae8e74d493db5c8b94a12c1eac6",
+    "wof:geomhash":"fed0f05fc5b2e5590d0e0973324bb3e1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092036283,
-    "wof:lastmodified":1690939732,
+    "wof:lastmodified":1695886846,
     "wof:name":"Dadal",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/632/5/1092036325.geojson
+++ b/data/109/203/632/5/1092036325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.468135,
-    "geom:area_square_m":4021460482.93153,
+    "geom:area_square_m":4021460067.506562,
     "geom:bbox":"108.507987,45.518737,109.683668,46.504077",
     "geom:latitude":45.994418,
     "geom:longitude":108.96006,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DG.DA",
         "wd:id":"Q3396380"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897984,
-    "wof:geomhash":"347f452bfbcfc468463bd0598a295ff3",
+    "wof:geomhash":"4da7a34123153d16c93ecf87d26aae9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092036325,
-    "wof:lastmodified":1690939738,
+    "wof:lastmodified":1695886016,
     "wof:name":"Dalanjargalan",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/203/635/3/1092036353.geojson
+++ b/data/109/203/635/3/1092036353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002449,
-    "geom:area_square_m":21940517.272499,
+    "geom:area_square_m":21940620.869264,
     "geom:bbox":"104.397483,43.549928,104.461541,43.604161",
     "geom:latitude":43.577381,
     "geom:longitude":104.426917,
@@ -218,9 +218,10 @@
         "hasc:id":"MN.OG.DA",
         "wd:id":"Q822808"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897985,
-    "wof:geomhash":"175d8300eff33e1299bb0c3ac651f686",
+    "wof:geomhash":"dc85b51c147d45f72def157ef1ed92b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -230,7 +231,7 @@
         }
     ],
     "wof:id":1092036353,
-    "wof:lastmodified":1690939738,
+    "wof:lastmodified":1695886846,
     "wof:name":"Dalanzadgad",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/639/1/1092036391.geojson
+++ b/data/109/203/639/1/1092036391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.553998,
-    "geom:area_square_m":4806154395.671762,
+    "geom:area_square_m":4806154319.821815,
     "geom:bbox":"113.477854,45.030374,114.734334,45.842958",
     "geom:latitude":45.444411,
     "geom:longitude":114.13084,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.SB.DA",
         "wd:id":"Q3403796"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897987,
-    "wof:geomhash":"aea6d799cab9c9bd73232977281388df",
+    "wof:geomhash":"87256bab946e8fa7088d288b3fcb80db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092036391,
-    "wof:lastmodified":1690939756,
+    "wof:lastmodified":1695886016,
     "wof:name":"Dariganga",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/203/643/5/1092036435.geojson
+++ b/data/109/203/643/5/1092036435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.409787,
-    "geom:area_square_m":3487407725.845416,
+    "geom:area_square_m":3487407754.288979,
     "geom:bbox":"93.610527,46.131747,94.745678,46.853218",
     "geom:latitude":46.508338,
     "geom:longitude":94.302608,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"MN.GA.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897988,
-    "wof:geomhash":"b8fe6a10e6a714f506398f04c68943bf",
+    "wof:geomhash":"177b4b4dcbc9e0cdc3450a95706dccaf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1092036435,
-    "wof:lastmodified":1627522368,
+    "wof:lastmodified":1695886016,
     "wof:name":"Darvi",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/646/3/1092036463.geojson
+++ b/data/109/203/646/3/1092036463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.658997,
-    "geom:area_square_m":5555191202.695508,
+    "geom:area_square_m":5555191271.643879,
     "geom:bbox":"93.034927,46.600224,94.30601,47.571109",
     "geom:latitude":47.020371,
     "geom:longitude":93.671455,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HD.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897989,
-    "wof:geomhash":"f0b4991f89c93ec2c134256fba867f29",
+    "wof:geomhash":"ea7df4683fd063af525e7774e8e8e10a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1092036463,
-    "wof:lastmodified":1627522368,
+    "wof:lastmodified":1695886016,
     "wof:name":"Darvi",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/650/7/1092036507.geojson
+++ b/data/109/203/650/7/1092036507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012355,
-    "geom:area_square_m":99267080.774824,
+    "geom:area_square_m":99267097.195296,
     "geom:bbox":"105.89341,49.393089,106.020564,49.533772",
     "geom:latitude":49.473546,
     "geom:longitude":105.95209,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.DA.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897991,
-    "wof:geomhash":"a89f23f95a0c018d184c2c0635d13328",
+    "wof:geomhash":"e98ee9e45e2240e33aca2c69bb474d87",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092036507,
-    "wof:lastmodified":1627522368,
+    "wof:lastmodified":1695886016,
     "wof:name":"Darxan",
     "wof:parent_id":85674769,
     "wof:placetype":"county",

--- a/data/109/203/654/9/1092036549.geojson
+++ b/data/109/203/654/9/1092036549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.52954,
-    "geom:area_square_m":4505077400.578461,
+    "geom:area_square_m":4505077586.113676,
     "geom:bbox":"108.951443,46.170064,110.068476,47.010153",
     "geom:latitude":46.525911,
     "geom:longitude":109.476287,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.HN.DH",
         "wd:id":"Q3404301"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897992,
-    "wof:geomhash":"cbf7e6821e8fe0aaaee202640e1f2a2a",
+    "wof:geomhash":"f3f7da0b11795eb412e1103acd32fb36",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092036549,
-    "wof:lastmodified":1690939758,
+    "wof:lastmodified":1695886848,
     "wof:name":"Darxan",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/659/5/1092036595.geojson
+++ b/data/109/203/659/5/1092036595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.091771,
-    "geom:area_square_m":8736894354.311903,
+    "geom:area_square_m":8736894154.390358,
     "geom:bbox":"113.544152,49.053454,115.044205,50.285431",
     "geom:latitude":49.670102,
     "geom:longitude":114.228849,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.DD.DA",
         "wd:id":"Q3404356"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897994,
-    "wof:geomhash":"582d368522cb20666779b58d82529ad2",
+    "wof:geomhash":"02dcd007c74e79eebded812612c64c0a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092036595,
-    "wof:lastmodified":1690939738,
+    "wof:lastmodified":1695886846,
     "wof:name":"Dashbalbar",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/663/1/1092036631.geojson
+++ b/data/109/203/663/1/1092036631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.277671,
-    "geom:area_square_m":2306813068.18926,
+    "geom:area_square_m":2306813419.971418,
     "geom:bbox":"103.648144,47.506206,104.501377,48.205378",
     "geom:latitude":47.788795,
     "geom:longitude":104.102271,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BU.DA",
         "wd:id":"Q2606094"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897995,
-    "wof:geomhash":"54b33654e0ef64e4f3db6519376895e6",
+    "wof:geomhash":"ccab8cc172ae84ae118b8484d6ee6e67",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092036631,
-    "wof:lastmodified":1690939756,
+    "wof:lastmodified":1695886017,
     "wof:name":"Dashinchilen",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/203/666/5/1092036665.geojson
+++ b/data/109/203/666/5/1092036665.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MN.UV.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897997,
     "wof:geomhash":"66885caadbb4a22372e12af8ce60a990",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092036665,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886284,
     "wof:name":"Davst",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/203/671/1/1092036711.geojson
+++ b/data/109/203/671/1/1092036711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.292148,
-    "geom:area_square_m":2497097206.518681,
+    "geom:area_square_m":2497097451.549449,
     "geom:bbox":"105.925016,45.939757,106.594272,46.593537",
     "geom:latitude":46.271106,
     "geom:longitude":106.250233,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.DU.DT",
         "wd:id":"Q3410026"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473897998,
-    "wof:geomhash":"2b470c0ec82703d1a0a5e45d5a7d1934",
+    "wof:geomhash":"477fa87741141a6a8ea33d7c7115485c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092036711,
-    "wof:lastmodified":1690939751,
+    "wof:lastmodified":1695886017,
     "wof:name":"Delgercogt",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/673/7/1092036737.geojson
+++ b/data/109/203/673/7/1092036737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.558394,
-    "geom:area_square_m":4812766231.905129,
+    "geom:area_square_m":4812766598.6714,
     "geom:bbox":"110.74441,45.470118,111.788943,46.235922",
     "geom:latitude":45.810335,
     "geom:longitude":111.304898,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DG.DE",
         "wd:id":"Q3396408"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898000,
-    "wof:geomhash":"ff72bb3c05f490a33b6c8ddb0d18a0b5",
+    "wof:geomhash":"0a07cf94c3175c74572712553ed0d1bf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092036737,
-    "wof:lastmodified":1690939733,
+    "wof:lastmodified":1695886017,
     "wof:name":"Delgerex",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/203/677/7/1092036777.geojson
+++ b/data/109/203/677/7/1092036777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.772776,
-    "geom:area_square_m":6614858866.521749,
+    "geom:area_square_m":6614858829.413115,
     "geom:bbox":"96.73377,45.705477,98.454625,46.725198",
     "geom:latitude":46.19068,
     "geom:longitude":97.52169,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.GA.DE",
         "wd:id":"Q3404324"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898001,
-    "wof:geomhash":"99c3871b945e241d7d21e2934761b366",
+    "wof:geomhash":"cecf06068d26a3699b94724ba0494914",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092036777,
-    "wof:lastmodified":1690939754,
+    "wof:lastmodified":1695886017,
     "wof:name":"Delger",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/681/7/1092036817.geojson
+++ b/data/109/203/681/7/1092036817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.254889,
-    "geom:area_square_m":2161839214.029504,
+    "geom:area_square_m":2161839243.360951,
     "geom:bbox":"104.240939,46.38516,104.991849,46.972407",
     "geom:latitude":46.69202,
     "geom:longitude":104.607137,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.TO.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898003,
-    "wof:geomhash":"d48b025f2e3daee210a8427b02f1a8b6",
+    "wof:geomhash":"bc3a059b4d015f03b44574de13491a35",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092036817,
-    "wof:lastmodified":1627522368,
+    "wof:lastmodified":1695886017,
     "wof:name":"Delgerxaan",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/685/1/1092036851.geojson
+++ b/data/109/203/685/1/1092036851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.457226,
-    "geom:area_square_m":3835840273.465295,
+    "geom:area_square_m":3835839994.944194,
     "geom:bbox":"108.404512,46.944223,109.514979,47.638328",
     "geom:latitude":47.275845,
     "geom:longitude":108.966101,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HN.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898004,
-    "wof:geomhash":"580d8325d34ee237fc81046fbaa05f80",
+    "wof:geomhash":"a131178127c5bfc78f3a7c3ff221abfd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092036851,
-    "wof:lastmodified":1627522369,
+    "wof:lastmodified":1695886017,
     "wof:name":"Delgerxaan",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/688/9/1092036889.geojson
+++ b/data/109/203/688/9/1092036889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.711174,
-    "geom:area_square_m":6204879617.611087,
+    "geom:area_square_m":6204879330.752348,
     "geom:bbox":"104.080083,44.690272,105.212894,45.594943",
     "geom:latitude":45.121859,
     "geom:longitude":104.663387,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DU.DH",
         "wd:id":"Q3404319"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898006,
-    "wof:geomhash":"399d95c0020c678c35efc06691d1e970",
+    "wof:geomhash":"bdd363947dba5c0089f920cdcb16453a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092036889,
-    "wof:lastmodified":1690939731,
+    "wof:lastmodified":1695886017,
     "wof:name":"Delgerxangai",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/693/1/1092036931.geojson
+++ b/data/109/203/693/1/1092036931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.674625,
-    "geom:area_square_m":5605027086.931211,
+    "geom:area_square_m":5605026712.134016,
     "geom:bbox":"90.048519,47.281703,91.253553,48.206888",
     "geom:latitude":47.784568,
     "geom:longitude":90.623033,
@@ -116,9 +116,10 @@
         "hasc:id":"MN.BO.DE",
         "wd:id":"Q2089882"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898007,
-    "wof:geomhash":"c36a070ab163305d4ffea72cb1997192",
+    "wof:geomhash":"adb662f83586e7deac0ba9c1ed600c05",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1092036931,
-    "wof:lastmodified":1690939737,
+    "wof:lastmodified":1695886846,
     "wof:name":"Delu'un",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/697/3/1092036973.geojson
+++ b/data/109/203/697/3/1092036973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.421083,
-    "geom:area_square_m":3601201957.573987,
+    "geom:area_square_m":3601202094.987665,
     "geom:bbox":"106.395928,45.831789,107.190762,46.596608",
     "geom:latitude":46.239796,
     "geom:longitude":106.800587,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.DU.DR",
         "wd:id":"Q3410089"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898009,
-    "wof:geomhash":"8be8b55c5d20cc03fe0d2cf47258164b",
+    "wof:geomhash":"817cef8b20aae9310ca4505acbcfd3b5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092036973,
-    "wof:lastmodified":1690939755,
+    "wof:lastmodified":1695886017,
     "wof:name":"Deren",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/699/9/1092036999.geojson
+++ b/data/109/203/699/9/1092036999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.498188,
-    "geom:area_square_m":4092932943.281123,
+    "geom:area_square_m":4092933479.753502,
     "geom:bbox":"92.234096,48.028102,93.510298,48.649275",
     "geom:latitude":48.362292,
     "geom:longitude":92.836728,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.HD.DO",
         "wd:id":"Q3300878"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898010,
-    "wof:geomhash":"f92307f322bd6a548b57e722f5bc34af",
+    "wof:geomhash":"7ffe1d61f4f724932ccdd9a13ed1d2e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092036999,
-    "wof:lastmodified":1690939755,
+    "wof:lastmodified":1695886848,
     "wof:name":"Do'rgon",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/703/9/1092037039.geojson
+++ b/data/109/203/703/9/1092037039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.871064,
-    "geom:area_square_m":7211308597.901757,
+    "geom:area_square_m":7211308859.154507,
     "geom:bbox":"93.262098,47.551019,95.437657,48.550154",
     "geom:latitude":47.969636,
     "geom:longitude":94.095149,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DZ.DO",
         "wd:id":"Q3402346"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898011,
-    "wof:geomhash":"fe5f24595032905f8b17ec8482b001e8",
+    "wof:geomhash":"48164f96925d200a435ecd9fd0142faa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092037039,
-    "wof:lastmodified":1690939749,
+    "wof:lastmodified":1695886017,
     "wof:name":"Do'rvoljin",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/708/5/1092037085.geojson
+++ b/data/109/203/708/5/1092037085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25563,
-    "geom:area_square_m":2135250889.208084,
+    "geom:area_square_m":2135250877.371281,
     "geom:bbox":"91.171721,47.240636,91.886601,47.851679",
     "geom:latitude":47.505583,
     "geom:longitude":91.484686,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.HD.DU",
         "wd:id":"Q3300822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898013,
-    "wof:geomhash":"ecea70c272931cbdac82d56080ffb420",
+    "wof:geomhash":"b7c084589afd51a45c88442f97880976",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092037085,
-    "wof:lastmodified":1690939729,
+    "wof:lastmodified":1695886845,
     "wof:name":"Duut",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/712/1/1092037121.geojson
+++ b/data/109/203/712/1/1092037121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.33541,
-    "geom:area_square_m":2750203661.92065,
+    "geom:area_square_m":2750203360.680536,
     "geom:bbox":"90.654385,48.197754,91.681866,48.708334",
     "geom:latitude":48.462218,
     "geom:longitude":91.195973,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.HD.ER",
         "wd:id":"Q3300811"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898014,
-    "wof:geomhash":"fc5f6a74c5523bb7fe3bccb2694fe81c",
+    "wof:geomhash":"83fdc28fe00e2a1261e236a3a252c8d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092037121,
-    "wof:lastmodified":1690939743,
+    "wof:lastmodified":1695886847,
     "wof:name":"Erdenebu'ren",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/716/1/1092037161.geojson
+++ b/data/109/203/716/1/1092037161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007357,
-    "geom:area_square_m":61472618.580057,
+    "geom:area_square_m":61472693.110476,
     "geom:bbox":"101.397084,47.448707,101.53042,47.555543",
     "geom:latitude":47.485441,
     "geom:longitude":101.46047,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.AR.EB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898016,
-    "wof:geomhash":"dcc3e74c8884b35df9d146f1e430b620",
+    "wof:geomhash":"4ae6b517f582aa3ede1b94c818491def",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092037161,
-    "wof:lastmodified":1627522369,
+    "wof:lastmodified":1695886018,
     "wof:name":"Erdenebulgan",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/720/5/1092037205.geojson
+++ b/data/109/203/720/5/1092037205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.622293,
-    "geom:area_square_m":4924392483.565829,
+    "geom:area_square_m":4924392205.742538,
     "geom:bbox":"101.090014,49.770724,102.622839,50.667511",
     "geom:latitude":50.210455,
     "geom:longitude":101.844331,
@@ -113,9 +113,10 @@
         "hasc:id":"MN.HG.ER",
         "wd:id":"Q3410244"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898017,
-    "wof:geomhash":"ed1275555014b7634bf1144b550bd50d",
+    "wof:geomhash":"d2f658e9ce795784fb8de842b6045f66",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1092037205,
-    "wof:lastmodified":1690939763,
+    "wof:lastmodified":1695886848,
     "wof:name":"Erdenebulgan",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/720/7/1092037207.geojson
+++ b/data/109/203/720/7/1092037207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.966727,
-    "geom:area_square_m":16880616647.280725,
+    "geom:area_square_m":16880616511.802727,
     "geom:bbox":"114.467152,45.376507,116.575969,46.629181",
     "geom:latitude":46.040922,
     "geom:longitude":115.436022,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.SB.ER",
         "wd:id":"Q3402197"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898020,
-    "wof:geomhash":"0c8d4e5d5145a8f3e0a8b23a254662e5",
+    "wof:geomhash":"01036590c6c68d912da36343e4f0ee7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092037207,
-    "wof:lastmodified":1690939763,
+    "wof:lastmodified":1695886018,
     "wof:name":"Erdenecagaan",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/203/720/9/1092037209.geojson
+++ b/data/109/203/720/9/1092037209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.474772,
-    "geom:area_square_m":4037472320.342413,
+    "geom:area_square_m":4037472945.30317,
     "geom:bbox":"100.531902,46.22957,101.55217,46.870893",
     "geom:latitude":46.548438,
     "geom:longitude":101.023246,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BH.ER",
         "wd:id":"Q2093804"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898021,
-    "wof:geomhash":"3622ad00b9a965492a40fc021367a031",
+    "wof:geomhash":"09e4bf712bde6d012b7969a66323d1a8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092037209,
-    "wof:lastmodified":1690939763,
+    "wof:lastmodified":1695886018,
     "wof:name":"Erdenecogt",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/721/7/1092037217.geojson
+++ b/data/109/203/721/7/1092037217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.84928,
-    "geom:area_square_m":7289825272.651014,
+    "geom:area_square_m":7289825000.217173,
     "geom:bbox":"104.228313,45.457585,105.554625,46.589146",
     "geom:latitude":46.038402,
     "geom:longitude":104.955587,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DU.ER",
         "wd:id":"Q1000390"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898023,
-    "wof:geomhash":"75c85eed5db200cdf3b7b51b5e9239ac",
+    "wof:geomhash":"5452b8911151b16a87b75976dbbe839c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092037217,
-    "wof:lastmodified":1690939761,
+    "wof:lastmodified":1695886023,
     "wof:name":"Erdenedalai",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/726/3/1092037263.geojson
+++ b/data/109/203/726/3/1092037263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.079494,
-    "geom:area_square_m":9565859389.436541,
+    "geom:area_square_m":9565858661.494987,
     "geom:bbox":"110.272185,43.484915,111.850846,44.876811",
     "geom:latitude":44.221041,
     "geom:longitude":111.13861,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DG.ER",
         "wd:id":"Q3404170"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898024,
-    "wof:geomhash":"1e4a2b1d0b85fc46ac9745fcaa876301",
+    "wof:geomhash":"a1d3770fa8cce8ce7e4f9fb09dbb8c8a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092037263,
-    "wof:lastmodified":1690939760,
+    "wof:lastmodified":1695886018,
     "wof:name":"Erdene",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/203/730/7/1092037307.geojson
+++ b/data/109/203/730/7/1092037307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.801222,
-    "geom:area_square_m":24912421194.051945,
+    "geom:area_square_m":24912420747.300159,
     "geom:bbox":"96.650001,42.701953,98.326091,45.372296",
     "geom:latitude":44.004326,
     "geom:longitude":97.442778,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.GA.ER",
         "wd:id":"Q3404218"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898026,
-    "wof:geomhash":"009967f40ab24d051217c0fd5db2e07a",
+    "wof:geomhash":"0c2b4bff7d1183e5e8ef95caaab273e3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092037307,
-    "wof:lastmodified":1690939728,
+    "wof:lastmodified":1695886018,
     "wof:name":"Erdene",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/732/3/1092037323.geojson
+++ b/data/109/203/732/3/1092037323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.411445,
-    "geom:area_square_m":3378438965.470573,
+    "geom:area_square_m":3378438642.878783,
     "geom:bbox":"100.919552,48.000769,101.961763,48.749341",
     "geom:latitude":48.389988,
     "geom:longitude":101.450181,
@@ -128,9 +128,10 @@
         "hasc:id":"MN.AR.EM",
         "wd:id":"Q2672420"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898027,
-    "wof:geomhash":"2de3254fcb31e51595baa5d36ade3c91",
+    "wof:geomhash":"65c09d2eefa7c8eeddb37a3c9ce922a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092037323,
-    "wof:lastmodified":1690939748,
+    "wof:lastmodified":1695886028,
     "wof:name":"Erdenemandal",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/736/9/1092037369.geojson
+++ b/data/109/203/736/9/1092037369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.36885,
-    "geom:area_square_m":3094270742.898978,
+    "geom:area_square_m":3094270808.419432,
     "geom:bbox":"104.035931,46.921238,104.975564,47.630078",
     "geom:latitude":47.278363,
     "geom:longitude":104.476198,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.TO.ES",
         "wd:id":"Q3396427"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898029,
-    "wof:geomhash":"70afb0f557feec36c1dafb9ea538dd68",
+    "wof:geomhash":"b34d216b53166ca7aec8f9db9a59e398",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092037369,
-    "wof:lastmodified":1690939730,
+    "wof:lastmodified":1695886018,
     "wof:name":"Erdenesant",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/739/3/1092037393.geojson
+++ b/data/109/203/739/3/1092037393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.982685,
-    "geom:area_square_m":8080114369.569627,
+    "geom:area_square_m":8080113828.929447,
     "geom:bbox":"107.087063,47.476098,108.271535,49.098574",
     "geom:latitude":48.318801,
     "geom:longitude":107.744111,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.TO.ER",
         "wd:id":"Q3396373"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898030,
-    "wof:geomhash":"4f85b77e2fff6cb5345e88e1d8d797fa",
+    "wof:geomhash":"f0aabdf3221b78a03f2de9af3dbf05a6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092037393,
-    "wof:lastmodified":1690939728,
+    "wof:lastmodified":1695886845,
     "wof:name":"Erdene",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/743/9/1092037439.geojson
+++ b/data/109/203/743/9/1092037439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.504058,
-    "geom:area_square_m":4157583749.412865,
+    "geom:area_square_m":4157583478.155667,
     "geom:bbox":"94.942378,47.791159,96.478779,48.554333",
     "geom:latitude":48.159886,
     "geom:longitude":95.794103,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.DZ.ER",
         "wd:id":"Q3402183"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898032,
-    "wof:geomhash":"171403c479cb8f5e3062daafc022941d",
+    "wof:geomhash":"b69226c55bba8b4b458e6962d886f41b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092037439,
-    "wof:lastmodified":1690939759,
+    "wof:lastmodified":1695886018,
     "wof:name":"Erdenexairxan",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/748/7/1092037487.geojson
+++ b/data/109/203/748/7/1092037487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.781394,
-    "geom:area_square_m":6644185983.306005,
+    "geom:area_square_m":6644185934.056881,
     "geom:bbox":"110.031861,46.059307,111.436264,46.955099",
     "geom:latitude":46.554834,
     "geom:longitude":110.797035,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.HN.GA",
         "wd:id":"Q3404262"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898033,
-    "wof:geomhash":"b78416de840bb4f9f1681b39d096d107",
+    "wof:geomhash":"93d223c54c993fe4b3f3cf9ce3c6e772",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092037487,
-    "wof:lastmodified":1690939744,
+    "wof:lastmodified":1695886847,
     "wof:name":"Galshir",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/752/5/1092037525.geojson
+++ b/data/109/203/752/5/1092037525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.4262,
-    "geom:area_square_m":3473562837.899247,
+    "geom:area_square_m":3473562876.221645,
     "geom:bbox":"99.53521,48.384135,100.594902,49.109108",
     "geom:latitude":48.767472,
     "geom:longitude":100.054941,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.HG.GA",
         "wd:id":"Q2607761"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898035,
-    "wof:geomhash":"b175100c0dfa54b78bb6cc93bdf6f458",
+    "wof:geomhash":"920a3cc341924785f2faa67f8a5b4f4c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092037525,
-    "wof:lastmodified":1690939726,
+    "wof:lastmodified":1695886845,
     "wof:name":"Galt",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/756/5/1092037565.geojson
+++ b/data/109/203/756/5/1092037565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.592688,
-    "geom:area_square_m":5021263724.269717,
+    "geom:area_square_m":5021263573.131748,
     "geom:bbox":"99.355857,46.301187,100.670952,47.195376",
     "geom:latitude":46.752208,
     "geom:longitude":100.126737,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.BH.GA",
         "wd:id":"Q2089823"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898036,
-    "wof:geomhash":"a41277f7e10c6720a6704dfacbadb07d",
+    "wof:geomhash":"83cd3f101463218c59aa681ea642bf4c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092037565,
-    "wof:lastmodified":1690939747,
+    "wof:lastmodified":1695886018,
     "wof:name":"Galuut",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/760/7/1092037607.geojson
+++ b/data/109/203/760/7/1092037607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.314005,
-    "geom:area_square_m":2696506116.960979,
+    "geom:area_square_m":2696505879.22993,
     "geom:bbox":"107.12626,45.69178,107.818707,46.304192",
     "geom:latitude":46.013415,
     "geom:longitude":107.466339,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.DU.GU",
         "wd:id":"Q3404210"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898038,
-    "wof:geomhash":"90da8395893dab3a56a99a4ed652f113",
+    "wof:geomhash":"40346b51741715b82fc0d43f58dac33e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092037607,
-    "wof:lastmodified":1690939747,
+    "wof:lastmodified":1695886019,
     "wof:name":"Govi-Ugtaal",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/765/1/1092037651.geojson
+++ b/data/109/203/765/1/1092037651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.54737,
-    "geom:area_square_m":4763000890.219834,
+    "geom:area_square_m":4763001276.969166,
     "geom:bbox":"101.854618,44.898208,102.880969,45.781688",
     "geom:latitude":45.273573,
     "geom:longitude":102.395456,
@@ -116,9 +116,10 @@
         "hasc:id":"MN.OH.GU",
         "wd:id":"Q3402397"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898039,
-    "wof:geomhash":"62bc90387080ff4c2c185436f314d59b",
+    "wof:geomhash":"9d21d88c0d6c4f7fe2d339117998f51c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1092037651,
-    "wof:lastmodified":1690939729,
+    "wof:lastmodified":1695886845,
     "wof:name":"Guchin-Us",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/769/5/1092037695.geojson
+++ b/data/109/203/769/5/1092037695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.526699,
-    "geom:area_square_m":4418384574.751949,
+    "geom:area_square_m":4418385628.674486,
     "geom:bbox":"98.088187,46.819831,99.059833,47.739982",
     "geom:latitude":47.279158,
     "geom:longitude":98.602903,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BH.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898041,
-    "wof:geomhash":"e5acd88c89445ab3fe49958ba709f350",
+    "wof:geomhash":"316d40e463e5ed8bb803e0ff3009ebbf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1092037695,
-    "wof:lastmodified":1627522370,
+    "wof:lastmodified":1695886019,
     "wof:name":"Gurvanbulag",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/773/7/1092037737.geojson
+++ b/data/109/203/773/7/1092037737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.322386,
-    "geom:area_square_m":2679693996.395889,
+    "geom:area_square_m":2679693709.64047,
     "geom:bbox":"102.958259,47.389965,103.822094,48.098536",
     "geom:latitude":47.761542,
     "geom:longitude":103.422583,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BU.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898042,
-    "wof:geomhash":"cfcf3794b2e486a1022b23fc44f99e4b",
+    "wof:geomhash":"0c02443ffa2328bd3f3e29afcc0b0f51",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1092037737,
-    "wof:lastmodified":1627522370,
+    "wof:lastmodified":1695886019,
     "wof:name":"Gurvanbulag",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/203/778/5/1092037785.geojson
+++ b/data/109/203/778/5/1092037785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.630701,
-    "geom:area_square_m":5464048743.930033,
+    "geom:area_square_m":5464049093.128974,
     "geom:bbox":"106.384917,45.227704,107.822294,45.939792",
     "geom:latitude":45.522013,
     "geom:longitude":107.115257,
@@ -110,9 +110,10 @@
         "hasc:id":"MN.DU.GS",
         "wd:id":"Q3404406"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898044,
-    "wof:geomhash":"6ab911a71c170bb2296d629c21da1a07",
+    "wof:geomhash":"193c56db8e9f51cd0047731c4a24c389",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1092037785,
-    "wof:lastmodified":1690939741,
+    "wof:lastmodified":1695886019,
     "wof:name":"Gurvansaixan",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/781/3/1092037813.geojson
+++ b/data/109/203/781/3/1092037813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.094694,
-    "geom:area_square_m":27851743980.238823,
+    "geom:area_square_m":27851744039.843792,
     "geom:bbox":"99.42928,42.503632,102.017111,44.160335",
     "geom:latitude":43.293285,
     "geom:longitude":100.661945,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.OG.GU",
         "wd:id":"Q3402176"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898045,
-    "wof:geomhash":"648b1f9b34c7c99f7abbe0db391d3c37",
+    "wof:geomhash":"da42692e4f27f0f66cd7fbbd98a13f6b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092037813,
-    "wof:lastmodified":1690939760,
+    "wof:lastmodified":1695886019,
     "wof:name":"Gurvantes",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/785/7/1092037857.geojson
+++ b/data/109/203/785/7/1092037857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.650763,
-    "geom:area_square_m":5257102979.41856,
+    "geom:area_square_m":5257103390.017538,
     "geom:bbox":"114.267774,48.76546,115.577504,49.714504",
     "geom:latitude":49.207542,
     "geom:longitude":114.969772,
@@ -116,9 +116,10 @@
         "hasc:id":"MN.DD.GU",
         "wd:id":"Q3404308"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898046,
-    "wof:geomhash":"bcac1eac5836c7ec4dc81ff68866bafe",
+    "wof:geomhash":"47419db4a43b3b069791f98255116b92",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1092037857,
-    "wof:lastmodified":1690939742,
+    "wof:lastmodified":1695886846,
     "wof:name":"Gurvanzagal",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/789/7/1092037897.geojson
+++ b/data/109/203/789/7/1092037897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.448549,
-    "geom:area_square_m":3698255133.873488,
+    "geom:area_square_m":3698254459.961829,
     "geom:bbox":"97.042743,47.840951,98.067362,48.530802",
     "geom:latitude":48.180399,
     "geom:longitude":97.55656,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.DZ.ID",
         "wd:id":"Q3402189"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898048,
-    "wof:geomhash":"13b65cddec609a51e77ae623caa9e08b",
+    "wof:geomhash":"12f3b1b726fb1cb102945a74700f367f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092037897,
-    "wof:lastmodified":1690939761,
+    "wof:lastmodified":1695886019,
     "wof:name":"Ider",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/793/9/1092037939.geojson
+++ b/data/109/203/793/9/1092037939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.486673,
-    "geom:area_square_m":4171479295.665222,
+    "geom:area_square_m":4171479188.016841,
     "geom:bbox":"109.694502,45.685489,110.592981,46.633321",
     "geom:latitude":46.116508,
     "geom:longitude":110.158788,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DG.IH",
         "wd:id":"Q3874729"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898049,
-    "wof:geomhash":"11d31ea31752d520a16307a72c4e50a3",
+    "wof:geomhash":"c1890cdd673d9cc83f78a6655a2bfd08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092037939,
-    "wof:lastmodified":1690939746,
+    "wof:lastmodified":1695886019,
     "wof:name":"Ix xet",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/203/797/9/1092037979.geojson
+++ b/data/109/203/797/9/1092037979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.249039,
-    "geom:area_square_m":1998490804.819705,
+    "geom:area_square_m":1998490642.22091,
     "geom:bbox":"101.038651,49.212812,101.830139,49.802698",
     "geom:latitude":49.534894,
     "geom:longitude":101.477363,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HG.IU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898051,
-    "wof:geomhash":"cfb199ac35d71e18229debe842a79198",
+    "wof:geomhash":"6fd08acb4b42794c0719a8c74164831a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092037979,
-    "wof:lastmodified":1627522370,
+    "wof:lastmodified":1695886019,
     "wof:name":"Ix-Uul",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/801/9/1092038019.geojson
+++ b/data/109/203/801/9/1092038019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.462143,
-    "geom:area_square_m":3773914857.593782,
+    "geom:area_square_m":3773914366.382784,
     "geom:bbox":"98.383707,48.226353,99.20779,49.158627",
     "geom:latitude":48.668336,
     "geom:longitude":98.832653,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.DZ.IU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898053,
-    "wof:geomhash":"c9c249f58f7473fc8ae4e5d7ef2e4bc0",
+    "wof:geomhash":"7a1de41a971f9201d4fbd75ba6f2709a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092038019,
-    "wof:lastmodified":1627522370,
+    "wof:lastmodified":1695886019,
     "wof:name":"Ix-Uul",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/806/3/1092038063.geojson
+++ b/data/109/203/806/3/1092038063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.584126,
-    "geom:area_square_m":4874075279.02202,
+    "geom:area_square_m":4874075304.043197,
     "geom:bbox":"100.359862,46.867781,101.567272,48.209642",
     "geom:latitude":47.559593,
     "geom:longitude":100.963405,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.AR.IT",
         "wd:id":"Q2089519"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898054,
-    "wof:geomhash":"fd647e5c5d494be3defbf1c1e2d66cfd",
+    "wof:geomhash":"d7eee67a3ee7b3a5924b13679eadce9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092038063,
-    "wof:lastmodified":1690939757,
+    "wof:lastmodified":1695886848,
     "wof:name":"Ixtamir",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/808/7/1092038087.geojson
+++ b/data/109/203/808/7/1092038087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.435328,
-    "geom:area_square_m":3666034242.353164,
+    "geom:area_square_m":3666033686.613932,
     "geom:bbox":"95.424824,46.701133,96.347054,47.44",
     "geom:latitude":47.074032,
     "geom:longitude":95.881241,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.GA.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898055,
-    "wof:geomhash":"95f292e65c55a3b033ae863724967f2d",
+    "wof:geomhash":"029be05a7c862ad41e6dd7d14c207571",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092038087,
-    "wof:lastmodified":1627522370,
+    "wof:lastmodified":1695886019,
     "wof:name":"Jargalan",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/203/813/1/1092038131.geojson
+++ b/data/109/203/813/1/1092038131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.346155,
-    "geom:area_square_m":2827162166.140955,
+    "geom:area_square_m":2827162281.741206,
     "geom:bbox":"100.314891,48.335366,101.18462,48.973508",
     "geom:latitude":48.661043,
     "geom:longitude":100.731709,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.AR.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898057,
-    "wof:geomhash":"8b0f1b5242d8659fa0e880e0cf7bd060",
+    "wof:geomhash":"e3bb06a4277d2a6de061bb35fee17958",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092038131,
-    "wof:lastmodified":1627522371,
+    "wof:lastmodified":1695886020,
     "wof:name":"Jargalant",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/817/1/1092038171.geojson
+++ b/data/109/203/817/1/1092038171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.498826,
-    "geom:area_square_m":4190592110.479512,
+    "geom:area_square_m":4190591848.164456,
     "geom:bbox":"98.94952,46.606086,99.926313,47.661097",
     "geom:latitude":47.202783,
     "geom:longitude":99.522938,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BH.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898058,
-    "wof:geomhash":"d193ed9d3e5c8b1a0d362e2c2a7d7eda",
+    "wof:geomhash":"ac5d5d2af77b293cd68b99af4344b3ba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092038171,
-    "wof:lastmodified":1627522371,
+    "wof:lastmodified":1695886020,
     "wof:name":"Jargalant",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/820/5/1092038205.geojson
+++ b/data/109/203/820/5/1092038205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069136,
-    "geom:area_square_m":560414805.404443,
+    "geom:area_square_m":560414926.285295,
     "geom:bbox":"104.165046,48.902604,104.629473,49.170793",
     "geom:latitude":49.038891,
     "geom:longitude":104.38804,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.ER.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898060,
-    "wof:geomhash":"5b82ccb817af1b5cef5fc19b6227076e",
+    "wof:geomhash":"35f57048575a6580b49c09e94f97c8ed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092038205,
-    "wof:lastmodified":1627522371,
+    "wof:lastmodified":1695886020,
     "wof:name":"Jargalant",
     "wof:parent_id":85674751,
     "wof:placetype":"county",

--- a/data/109/203/825/1/1092038251.geojson
+++ b/data/109/203/825/1/1092038251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.225779,
-    "geom:area_square_m":1847157604.238623,
+    "geom:area_square_m":1847157230.314964,
     "geom:bbox":"105.451795,48.265468,106.118842,48.84346",
     "geom:latitude":48.575176,
     "geom:longitude":105.790817,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.TO.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898061,
-    "wof:geomhash":"6dedefd18a3ab2a7be70c04a7778010e",
+    "wof:geomhash":"ef892751c10f3f4fc2d516c533df8ddd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092038251,
-    "wof:lastmodified":1627522371,
+    "wof:lastmodified":1695886020,
     "wof:name":"Jargalant",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/829/7/1092038297.geojson
+++ b/data/109/203/829/7/1092038297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.321638,
-    "geom:area_square_m":2632915017.891091,
+    "geom:area_square_m":2632914947.304802,
     "geom:bbox":"99.065563,48.252978,99.790901,48.862235",
     "geom:latitude":48.546036,
     "geom:longitude":99.395633,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HG.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898063,
-    "wof:geomhash":"c66a45baf5976df7d4a551fe0eb13f45",
+    "wof:geomhash":"c54ba0aecdcc27a58ac33d83b9159e08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092038297,
-    "wof:lastmodified":1627522371,
+    "wof:lastmodified":1695886020,
     "wof:name":"Jargalant",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/833/5/1092038335.geojson
+++ b/data/109/203/833/5/1092038335.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MN.HD.BY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898064,
     "wof:geomhash":"371c5f5d15198b469e0a7551820099a6",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092038335,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886308,
     "wof:name":"Jargalant",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/836/9/1092038369.geojson
+++ b/data/109/203/836/9/1092038369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.34085,
-    "geom:area_square_m":2848316686.311897,
+    "geom:area_square_m":2848316686.31135,
     "geom:bbox":"109.06675,47.142823,109.903206,47.886895",
     "geom:latitude":47.482812,
     "geom:longitude":109.514084,
@@ -111,9 +111,10 @@
         "hasc:id":"MN.HN.JA",
         "wd:id":"Q1025038"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898065,
-    "wof:geomhash":"9c29a1205e6b3c4d20f2f4b9f79590a8",
+    "wof:geomhash":"03494924fa44acc51eafcc8ef79570a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1092038369,
-    "wof:lastmodified":1690939755,
+    "wof:lastmodified":1695886287,
     "wof:name":"Jargaltxaan",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/841/3/1092038413.geojson
+++ b/data/109/203/841/3/1092038413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147708,
-    "geom:area_square_m":1180256247.957817,
+    "geom:area_square_m":1180256444.986718,
     "geom:bbox":"106.028649,49.523198,106.616729,49.955894",
     "geom:latitude":49.743582,
     "geom:longitude":106.359151,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.SL.JA",
         "wd:id":"Q2747990"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898067,
-    "wof:geomhash":"ad3a1640da230b129c11f4899b0eb57e",
+    "wof:geomhash":"56a9466f1627665b9a308fe6e83ade3b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092038413,
-    "wof:lastmodified":1690939750,
+    "wof:lastmodified":1695886847,
     "wof:name":"Javxlant",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/203/845/7/1092038457.geojson
+++ b/data/109/203/845/7/1092038457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.59375,
-    "geom:area_square_m":5154195701.026935,
+    "geom:area_square_m":5154196135.529487,
     "geom:bbox":"99.591702,44.991588,100.97816,45.853432",
     "geom:latitude":45.409474,
     "geom:longitude":100.297294,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.BH.JI",
         "wd:id":"Q2089911"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898068,
-    "wof:geomhash":"75ccebeaa473c50b9eccf6520133af27",
+    "wof:geomhash":"1451d798e94fc2b8d5d574bd7ddb228f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092038457,
-    "wof:lastmodified":1690939732,
+    "wof:lastmodified":1695886020,
     "wof:name":"Jinst",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/203/848/7/1092038487.geojson
+++ b/data/109/203/848/7/1092038487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.304373,
-    "geom:area_square_m":2529061769.855146,
+    "geom:area_square_m":2529062190.929655,
     "geom:bbox":"104.633985,47.508092,105.675527,48.069245",
     "geom:latitude":47.780302,
     "geom:longitude":105.156611,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.TO.LU",
         "wd:id":"Q2089625"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898070,
-    "wof:geomhash":"a5560fab882a7b8b325e9889bbfda5b0",
+    "wof:geomhash":"26b6a7b0a27d4c19b32dca978f17e112",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092038487,
-    "wof:lastmodified":1690939751,
+    "wof:lastmodified":1695886020,
     "wof:name":"Lu'n",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/852/9/1092038529.geojson
+++ b/data/109/203/852/9/1092038529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.365069,
-    "geom:area_square_m":3158940973.792581,
+    "geom:area_square_m":3158940771.365969,
     "geom:bbox":"105.377676,45.229277,106.200618,45.985913",
     "geom:latitude":45.589904,
     "geom:longitude":105.787608,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DU.LU",
         "wd:id":"Q3409998"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898071,
-    "wof:geomhash":"fa33a442a0c96142aa0d25effbf9a75e",
+    "wof:geomhash":"9c3d553e7e8bda062ef91d063547b7f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092038529,
-    "wof:lastmodified":1690939758,
+    "wof:lastmodified":1695886020,
     "wof:name":"Luus",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/857/3/1092038573.geojson
+++ b/data/109/203/857/3/1092038573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.49883,
-    "geom:area_square_m":3989075885.840511,
+    "geom:area_square_m":3989075786.917622,
     "geom:bbox":"92.76594,49.268156,93.653213,50.156821",
     "geom:latitude":49.704637,
     "geom:longitude":93.217075,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.UV.MA",
         "wd:id":"Q3403806"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898073,
-    "wof:geomhash":"db225564132d5364d7b7d42150cfcf28",
+    "wof:geomhash":"41d8e9b8fa1e29097c023d72d5f54c25",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092038573,
-    "wof:lastmodified":1690939736,
+    "wof:lastmodified":1695886027,
     "wof:name":"Malchin",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/203/861/5/1092038615.geojson
+++ b/data/109/203/861/5/1092038615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.737856,
-    "geom:area_square_m":6487050410.383017,
+    "geom:area_square_m":6487050426.235472,
     "geom:bbox":"103.255798,44.213852,104.681043,45.173947",
     "geom:latitude":44.682574,
     "geom:longitude":104.003812,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.OG.MO",
         "wd:id":"Q3403970"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898074,
-    "wof:geomhash":"4761bb59411cf13866f2f0a45678ce29",
+    "wof:geomhash":"55dc64a9cb132710b0166cbb3e360131",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092038615,
-    "wof:lastmodified":1690939736,
+    "wof:lastmodified":1695886020,
     "wof:name":"Mandal-Ovoo",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/864/9/1092038649.geojson
+++ b/data/109/203/864/9/1092038649.geojson
@@ -94,6 +94,7 @@
         "hasc:id":"MN.SL.MA",
         "wd:id":"Q2748006"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898075,
     "wof:geomhash":"afd8d2be5a149c6693e3937a8c668730",
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1092038649,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886848,
     "wof:name":"Mandal",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/203/869/1/1092038691.geojson
+++ b/data/109/203/869/1/1092038691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.425363,
-    "geom:area_square_m":12641232034.284426,
+    "geom:area_square_m":12641232206.599579,
     "geom:bbox":"107.654808,43.489555,109.192446,44.900147",
     "geom:latitude":44.172107,
     "geom:longitude":108.376211,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DG.MA",
         "wd:id":"Q3396693"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898077,
-    "wof:geomhash":"1ff507b6bea45937afcac34b6018c41d",
+    "wof:geomhash":"ed671817c66a7b6817508483eb68559f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092038691,
-    "wof:lastmodified":1690939737,
+    "wof:lastmodified":1695886020,
     "wof:name":"Mandax",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/203/873/7/1092038737.geojson
+++ b/data/109/203/873/7/1092038737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.392965,
-    "geom:area_square_m":12401038684.773638,
+    "geom:area_square_m":12401038436.620543,
     "geom:bbox":"106.304752,43.373185,107.989203,44.530164",
     "geom:latitude":43.946937,
     "geom:longitude":107.128768,
@@ -92,9 +92,10 @@
         "hasc:id":"MN.OG.MA",
         "wd:id":"Q3403922"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898078,
-    "wof:geomhash":"8b401930c18e56d3415025e99ba4c7e5",
+    "wof:geomhash":"29522c885e024cccf7bd0098d21381f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092038737,
-    "wof:lastmodified":1690939732,
+    "wof:lastmodified":1695886020,
     "wof:name":"Manlai",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/877/3/1092038773.geojson
+++ b/data/109/203/877/3/1092038773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.515655,
-    "geom:area_square_m":4316774158.885788,
+    "geom:area_square_m":4316774637.536184,
     "geom:bbox":"91.765812,46.913771,92.786274,47.809753",
     "geom:latitude":47.388685,
     "geom:longitude":92.266209,
@@ -128,9 +128,10 @@
         "hasc:id":"MN.HD.MA",
         "wd:id":"Q3300311"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898080,
-    "wof:geomhash":"8e6e2e5386e6c35617628414fdd2228d",
+    "wof:geomhash":"4a17269ec6d2423fa51583944db0da9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092038773,
-    "wof:lastmodified":1690939751,
+    "wof:lastmodified":1695886847,
     "wof:name":"Manxan",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/881/3/1092038813.geojson
+++ b/data/109/203/881/3/1092038813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.702477,
-    "geom:area_square_m":22735477807.597282,
+    "geom:area_square_m":22735477866.324825,
     "geom:bbox":"114.445912,46.285924,116.995509,47.9177",
     "geom:latitude":47.126827,
     "geom:longitude":115.897985,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.DD.MA",
         "wd:id":"Q3410012"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898081,
-    "wof:geomhash":"0be348e4aaa132d080d1c31b2e802264",
+    "wof:geomhash":"8869a5c9930d5cd4cfb487595d3184fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092038813,
-    "wof:lastmodified":1690939734,
+    "wof:lastmodified":1695886021,
     "wof:name":"Matad",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/203/885/3/1092038853.geojson
+++ b/data/109/203/885/3/1092038853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.817709,
-    "geom:area_square_m":6694905191.753017,
+    "geom:area_square_m":6694905535.899168,
     "geom:bbox":"108.088039,47.920782,109.054574,49.154561",
     "geom:latitude":48.536576,
     "geom:longitude":108.553717,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.TO.MO",
         "wd:id":"Q3403761"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898083,
-    "wof:geomhash":"94aea3ef330ba2c665a0d8c1fed236e9",
+    "wof:geomhash":"1c12a8fdfd41c029f3d6900802c678a6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092038853,
-    "wof:lastmodified":1690939752,
+    "wof:lastmodified":1695886847,
     "wof:name":"Mo'ngonmorit",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/889/7/1092038897.geojson
+++ b/data/109/203/889/7/1092038897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.877609,
-    "geom:area_square_m":7383682327.220707,
+    "geom:area_square_m":7383681997.33577,
     "geom:bbox":"111.389169,46.688776,113.173136,47.645942",
     "geom:latitude":47.123908,
     "geom:longitude":112.256841,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.SB.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898084,
-    "wof:geomhash":"3fc8f49c65edde6f6031bf1a5eeb2b67",
+    "wof:geomhash":"c30f09231e8077341a82ddcaa1495e6a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092038897,
-    "wof:lastmodified":1627522372,
+    "wof:lastmodified":1695886021,
     "wof:name":"Mo'nxxaan",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/203/892/3/1092038923.geojson
+++ b/data/109/203/892/3/1092038923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.303692,
-    "geom:area_square_m":2560074063.760705,
+    "geom:area_square_m":2560073925.485723,
     "geom:bbox":"91.405858,46.688238,92.248538,47.317575",
     "geom:latitude":47.020213,
     "geom:longitude":91.792337,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.HD.MH",
         "wd:id":"Q374592"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898086,
-    "wof:geomhash":"f1a0e04dd94b9362fbe3863ee8258e8c",
+    "wof:geomhash":"7a3f08ce7fb1dea5e06af754ac4c6218",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092038923,
-    "wof:lastmodified":1690939735,
+    "wof:lastmodified":1695886846,
     "wof:name":"Mo'nxxairxan",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/896/1/1092038961.geojson
+++ b/data/109/203/896/1/1092038961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263052,
-    "geom:area_square_m":2205702728.605342,
+    "geom:area_square_m":2205703130.063333,
     "geom:bbox":"109.845051,47.003886,110.628076,47.606182",
     "geom:latitude":47.303135,
     "geom:longitude":110.242614,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.HN.MO",
         "wd:id":"Q3404195"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898088,
-    "wof:geomhash":"3b50c404ab43d78381150c69b0df1bc6",
+    "wof:geomhash":"53979fc5aba6f180c74db4133b12cf87",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092038961,
-    "wof:lastmodified":1690939756,
+    "wof:lastmodified":1695886848,
     "wof:name":"Mo'ron",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/900/1/1092039001.geojson
+++ b/data/109/203/900/1/1092039001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012822,
-    "geom:area_square_m":102674040.240908,
+    "geom:area_square_m":102673939.330739,
     "geom:bbox":"100.068686,49.569047,100.225334,49.701561",
     "geom:latitude":49.640174,
     "geom:longitude":100.149269,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HG.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898089,
-    "wof:geomhash":"9bc8c11938b20f43f97081d3669723f2",
+    "wof:geomhash":"0cbcc014ece79de4044dfd217cd89e9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092039001,
-    "wof:lastmodified":1627522372,
+    "wof:lastmodified":1695886021,
     "wof:name":"Mo'ron",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/203/903/3/1092039033.geojson
+++ b/data/109/203/903/3/1092039033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.470531,
-    "geom:area_square_m":3989900444.656427,
+    "geom:area_square_m":3989900751.401114,
     "geom:bbox":"91.94879,46.380563,93.247299,46.9947",
     "geom:latitude":46.704405,
     "geom:longitude":92.592224,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.HD.MS",
         "wd:id":"Q10950043"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898090,
-    "wof:geomhash":"1603849a7065b56d42142a1c2308fa96",
+    "wof:geomhash":"d7f964c4bdb61ae289d2910d1720d379",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092039033,
-    "wof:lastmodified":1690939747,
+    "wof:lastmodified":1695886847,
     "wof:name":"Mo'st",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/907/7/1092039077.geojson
+++ b/data/109/203/907/7/1092039077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.342151,
-    "geom:area_square_m":2815419493.212374,
+    "geom:area_square_m":2815419623.035602,
     "geom:bbox":"102.599918,47.854165,103.242027,48.659168",
     "geom:latitude":48.281744,
     "geom:longitude":102.927183,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.BU.MO",
         "wd:id":"Q2606090"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898092,
-    "wof:geomhash":"000c7575b846a5ef3c6bac298461ba7f",
+    "wof:geomhash":"4f603d98093a3e0a9ee757b01ff68bd9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092039077,
-    "wof:lastmodified":1690939727,
+    "wof:lastmodified":1695886021,
     "wof:name":"Mogod",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/203/912/3/1092039123.geojson
+++ b/data/109/203/912/3/1092039123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.401479,
-    "geom:area_square_m":3285321150.532558,
+    "geom:area_square_m":3285321497.836324,
     "geom:bbox":"91.339513,48.166322,92.342432,48.966417",
     "geom:latitude":48.56389,
     "geom:longitude":91.904296,
@@ -128,9 +128,10 @@
         "hasc:id":"MN.HD.MY",
         "wd:id":"Q3404082"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898093,
-    "wof:geomhash":"104b21456b41f3ef142574f388f4bb6c",
+    "wof:geomhash":"9348c0de13030e3d72fff8c488905624",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092039123,
-    "wof:lastmodified":1690939741,
+    "wof:lastmodified":1695886846,
     "wof:name":"Myangad",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/203/916/3/1092039163.geojson
+++ b/data/109/203/916/3/1092039163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083106,
-    "geom:area_square_m":690103834.562821,
+    "geom:area_square_m":690103409.340553,
     "geom:bbox":"107.214773,47.645311,107.617978,47.997778",
     "geom:latitude":47.812702,
     "geom:longitude":107.421284,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.UB.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898095,
-    "wof:geomhash":"0ce9fc607a9d226e3112a0f477804dda",
+    "wof:geomhash":"e30e1a5dfad73128518257be53f587bc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092039163,
-    "wof:lastmodified":1627522372,
+    "wof:lastmodified":1695886021,
     "wof:name":"Nalaix",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/203/920/9/1092039209.geojson
+++ b/data/109/203/920/9/1092039209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.644478,
-    "geom:area_square_m":5172337259.719457,
+    "geom:area_square_m":5172336889.40551,
     "geom:bbox":"92.007248,48.891779,92.983719,50.041683",
     "geom:latitude":49.529488,
     "geom:longitude":92.521394,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.UV.NA",
         "wd:id":"Q3403815"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898096,
-    "wof:geomhash":"4a14a6369f3bb071f5139e529737f299",
+    "wof:geomhash":"93506de0c42b6965abf0bb6cf4198809",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092039209,
-    "wof:lastmodified":1690939760,
+    "wof:lastmodified":1695886021,
     "wof:name":"Naranbulag",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/203/924/9/1092039249.geojson
+++ b/data/109/203/924/9/1092039249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.385132,
-    "geom:area_square_m":3364995162.240104,
+    "geom:area_square_m":3364995057.847372,
     "geom:bbox":"113.117726,44.742889,114.172909,45.504548",
     "geom:latitude":45.040849,
     "geom:longitude":113.598388,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.SB.NA",
         "wd:id":"Q3402144"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898098,
-    "wof:geomhash":"f6d358f2c90581e0f951204a72b399dc",
+    "wof:geomhash":"65a695f6e1789dcf10219785959d7669",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092039249,
-    "wof:lastmodified":1690939742,
+    "wof:lastmodified":1695886021,
     "wof:name":"Naran",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/203/929/5/1092039295.geojson
+++ b/data/109/203/929/5/1092039295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.311985,
-    "geom:area_square_m":2687304272.902048,
+    "geom:area_square_m":2687304576.21465,
     "geom:bbox":"101.224917,45.510254,101.856474,46.207639",
     "geom:latitude":45.845024,
     "geom:longitude":101.542311,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.OH.NA",
         "wd:id":"Q3402273"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898099,
-    "wof:geomhash":"abfd3ab3f5cd0d30bdb05eb1059256d6",
+    "wof:geomhash":"420b7ea54e1e3c4ca7cb532f5692b0c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092039295,
-    "wof:lastmodified":1690939759,
+    "wof:lastmodified":1695886021,
     "wof:name":"Nariinteel",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/931/9/1092039319.geojson
+++ b/data/109/203/931/9/1092039319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.400788,
-    "geom:area_square_m":3259759619.05757,
+    "geom:area_square_m":3259759603.997206,
     "geom:bbox":"96.474325,48.568384,97.349771,49.210352",
     "geom:latitude":48.870202,
     "geom:longitude":96.981462,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.DZ.NO",
         "wd:id":"Q3403853"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898101,
-    "wof:geomhash":"477ceeddc71f166e00d42a46247b9893",
+    "wof:geomhash":"5b3410661be067aeeccc4b3e8cd90781",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092039319,
-    "wof:lastmodified":1690939726,
+    "wof:lastmodified":1695886021,
     "wof:name":"No'mrog",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/203/936/7/1092039367.geojson
+++ b/data/109/203/936/7/1092039367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.653782,
-    "geom:area_square_m":5248376782.751307,
+    "geom:area_square_m":5248377119.618529,
     "geom:bbox":"89.18172,49.066422,90.686722,50.001541",
     "geom:latitude":49.516921,
     "geom:longitude":89.993721,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.BO.NO",
         "wd:id":"Q2593901"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898102,
-    "wof:geomhash":"45788096556aa0a094293a064ee54438",
+    "wof:geomhash":"48bbed085cff49628caff015b68ecbfb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092039367,
-    "wof:lastmodified":1690939725,
+    "wof:lastmodified":1695886845,
     "wof:name":"Nogoonnuur",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/940/9/1092039409.geojson
+++ b/data/109/203/940/9/1092039409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.016856,
-    "geom:area_square_m":18412756968.08263,
+    "geom:area_square_m":18412757038.843452,
     "geom:bbox":"104.188096,41.58152,105.954152,43.230625",
     "geom:latitude":42.41029,
     "geom:longitude":105.012197,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.OG.NG",
         "wd:id":"Q3402154"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898103,
-    "wof:geomhash":"dfb69ef7a12ac871937619ab000a5575",
+    "wof:geomhash":"1334f01c5aeb5769c9daabe09939fa0f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092039409,
-    "wof:lastmodified":1690939742,
+    "wof:lastmodified":1695886021,
     "wof:name":"Nomgon",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/944/7/1092039447.geojson
+++ b/data/109/203/944/7/1092039447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.668252,
-    "geom:area_square_m":5471204643.990554,
+    "geom:area_square_m":5471204137.060021,
     "geom:bbox":"111.546645,48.047137,112.576939,49.118747",
     "geom:latitude":48.53717,
     "geom:longitude":112.074444,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.HN.NO",
         "wd:id":"Q3404104"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898105,
-    "wof:geomhash":"065eef57a1896412053f9a2eb38bcd99",
+    "wof:geomhash":"e93d3a46b00e307e67d11f386d7fc589",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092039447,
-    "wof:lastmodified":1690939762,
+    "wof:lastmodified":1695886848,
     "wof:name":"Norovlin",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/949/1/1092039491.geojson
+++ b/data/109/203/949/1/1092039491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.1637,
-    "geom:area_square_m":10561730509.836664,
+    "geom:area_square_m":10561731222.538843,
     "geom:bbox":"101.800157,42.14242,102.948849,43.377528",
     "geom:latitude":42.776667,
     "geom:longitude":102.371721,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.OG.NY",
         "wd:id":"Q3402294"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898106,
-    "wof:geomhash":"b80c644a2f2e31f1a7b8de0ec9f90868",
+    "wof:geomhash":"4f088bc4b36bdddf4643a9bae8565f59",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092039491,
-    "wof:lastmodified":1690939743,
+    "wof:lastmodified":1695886021,
     "wof:name":"Noyon",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/203/953/3/1092039533.geojson
+++ b/data/109/203/953/3/1092039533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.203187,
-    "geom:area_square_m":1690221676.750499,
+    "geom:area_square_m":1690221702.660405,
     "geom:bbox":"102.235434,47.524694,103.062213,47.891787",
     "geom:latitude":47.721192,
     "geom:longitude":102.610446,
@@ -110,9 +110,10 @@
         "hasc:id":"MN.AR.UG",
         "wd:id":"Q2093495"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898108,
-    "wof:geomhash":"1e6a5b47d99c363ed470c87598046d51",
+    "wof:geomhash":"0259e85b73226179b6a6ef1c07863057",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1092039533,
-    "wof:lastmodified":1690939728,
+    "wof:lastmodified":1695886845,
     "wof:name":"O'giinuur",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/957/3/1092039573.geojson
+++ b/data/109/203/957/3/1092039573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01243,
-    "geom:area_square_m":100879216.777695,
+    "geom:area_square_m":100879282.298082,
     "geom:bbox":"89.860894,48.926815,90.071815,49.037012",
     "geom:latitude":48.979365,
     "geom:longitude":89.958905,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BO.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898109,
-    "wof:geomhash":"315c351adb1a358a1f2568a333a9090f",
+    "wof:geomhash":"cd160b21498d02be35f6cbb5e9ea6388",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092039573,
-    "wof:lastmodified":1627522373,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'lgii",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/203/960/3/1092039603.geojson
+++ b/data/109/203/960/3/1092039603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.292741,
-    "geom:area_square_m":2378453011.490938,
+    "geom:area_square_m":2378452522.237994,
     "geom:bbox":"91.86369,48.600291,92.609449,49.373995",
     "geom:latitude":48.923186,
     "geom:longitude":92.222519,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.UV.OL",
         "wd:id":"Q3403716"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898111,
-    "wof:geomhash":"aff9d3b7ba7fadaafef5861211b73327",
+    "wof:geomhash":"422089f34c9fef1b05d179cf918dd841",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092039603,
-    "wof:lastmodified":1690939748,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'lgii",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/203/964/5/1092039645.geojson
+++ b/data/109/203/964/5/1092039645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.206901,
-    "geom:area_square_m":1709061458.071293,
+    "geom:area_square_m":1709061407.496558,
     "geom:bbox":"102.176496,47.850316,102.828035,48.339593",
     "geom:latitude":48.08488,
     "geom:longitude":102.510105,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.AR.UL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898112,
-    "wof:geomhash":"5ec9bf87cf8d7e09edc3e93fa7ef16d2",
+    "wof:geomhash":"41f6bfad9c42ed7fbb58bd032e98a1ef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092039645,
-    "wof:lastmodified":1627522373,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'lziit",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/968/5/1092039685.geojson
+++ b/data/109/203/968/5/1092039685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.749406,
-    "geom:area_square_m":15351347375.411058,
+    "geom:area_square_m":15351347551.529621,
     "geom:bbox":"105.476712,44.166209,107.870227,45.423966",
     "geom:latitude":44.791434,
     "geom:longitude":106.698035,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.DU.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898113,
-    "wof:geomhash":"36129ddd1b8d0a66600fd6bf9bf16a86",
+    "wof:geomhash":"2121d958ad4ac3c1d1574fe80bfd9222",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092039685,
-    "wof:lastmodified":1627522373,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'lziit",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/972/1/1092039721.geojson
+++ b/data/109/203/972/1/1092039721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231233,
-    "geom:area_square_m":1968234710.648181,
+    "geom:area_square_m":1968234643.694199,
     "geom:bbox":"102.948525,46.205065,103.73168,46.830145",
     "geom:latitude":46.498153,
     "geom:longitude":103.399408,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.OH.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898115,
-    "wof:geomhash":"25d11613d9410f45636933016f87c638",
+    "wof:geomhash":"5c8cde4169394a530fe9eff0fab20590",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092039721,
-    "wof:lastmodified":1627522373,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'lziit",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/203/976/1/1092039761.geojson
+++ b/data/109/203/976/1/1092039761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.320607,
-    "geom:area_square_m":10848924718.70118,
+    "geom:area_square_m":10848925460.243731,
     "geom:bbox":"108.510001,47.629875,110.550132,49.347618",
     "geom:latitude":48.364165,
     "geom:longitude":109.539196,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.HN.OM",
         "wd:id":"Q8078978"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898116,
-    "wof:geomhash":"4d47363f750758435ee2a7bee36f6c2a",
+    "wof:geomhash":"d6988d3fc92d78db2e24460bb6c9c3ab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092039761,
-    "wof:lastmodified":1690939744,
+    "wof:lastmodified":1695886847,
     "wof:name":"O'mnodelger",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/203/980/1/1092039801.geojson
+++ b/data/109/203/980/1/1092039801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.387799,
-    "geom:area_square_m":3138242810.859838,
+    "geom:area_square_m":3138243642.022215,
     "geom:bbox":"91.058673,48.680839,92.060683,49.519541",
     "geom:latitude":49.121452,
     "geom:longitude":91.612266,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.UV.OM",
         "wd:id":"Q3402376"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898118,
-    "wof:geomhash":"351f5763b8ecca6f33018926816dcac8",
+    "wof:geomhash":"e08684e563bd33cebef722d362be5fce",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092039801,
-    "wof:lastmodified":1690939761,
+    "wof:lastmodified":1695886028,
     "wof:name":"O'mnogovi",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/203/984/5/1092039845.geojson
+++ b/data/109/203/984/5/1092039845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.525866,
-    "geom:area_square_m":4346912934.947636,
+    "geom:area_square_m":4346912555.208009,
     "geom:bbox":"100.081995,47.61079,101.425635,48.411381",
     "geom:latitude":48.047971,
     "geom:longitude":100.720843,
@@ -113,9 +113,10 @@
         "hasc:id":"MN.AR.OU",
         "wd:id":"Q2089903"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898119,
-    "wof:geomhash":"4f4f6e6beb620cff0f3c470476210e98",
+    "wof:geomhash":"b57545eb021eeaa433c8073ed503c345",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1092039845,
-    "wof:lastmodified":1690939740,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'ndor-Ulaan",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/203/985/9/1092039859.geojson
+++ b/data/109/203/985/9/1092039859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.556993,
-    "geom:area_square_m":4850318024.216765,
+    "geom:area_square_m":4850318112.480696,
     "geom:bbox":"107.600539,44.857622,108.67,45.676327",
     "geom:latitude":45.231664,
     "geom:longitude":108.168247,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DU.ON",
         "wd:id":"Q3404249"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898121,
-    "wof:geomhash":"0f85129dee0a77c75e0181cba6535f54",
+    "wof:geomhash":"9f93f084989be63ed02e093b45582b9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092039859,
-    "wof:lastmodified":1690939743,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'ndorshil",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/203/990/5/1092039905.geojson
+++ b/data/109/203/990/5/1092039905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.312694,
-    "geom:area_square_m":2615127592.365582,
+    "geom:area_square_m":2615127426.097279,
     "geom:bbox":"104.481692,47.164535,105.474366,47.709721",
     "geom:latitude":47.440761,
     "geom:longitude":105.020732,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.TO.ON",
         "wd:id":"Q3396418"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898122,
-    "wof:geomhash":"197a1d680b9b516ab214a272ba3eb194",
+    "wof:geomhash":"3bbe593e6289b090ab3562bc3c9efdb1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092039905,
-    "wof:lastmodified":1690939730,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'ndorshireet",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/203/994/7/1092039947.geojson
+++ b/data/109/203/994/7/1092039947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.571727,
-    "geom:area_square_m":4624144055.590565,
+    "geom:area_square_m":4624144071.719949,
     "geom:bbox":"94.496343,48.671665,95.239915,49.64621",
     "geom:latitude":49.148331,
     "geom:longitude":94.847006,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.UV.ON",
         "wd:id":"Q3403723"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898124,
-    "wof:geomhash":"242c0287c43f46b0c29475abc7521c9f",
+    "wof:geomhash":"4f7334277755b56d11ffa8f2e012ea9b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092039947,
-    "wof:lastmodified":1690939749,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'ndorxangai",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/203/998/5/1092039985.geojson
+++ b/data/109/203/998/5/1092039985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.960522,
-    "geom:area_square_m":8391793359.535257,
+    "geom:area_square_m":8391792982.783985,
     "geom:bbox":"110.153854,44.571889,111.986236,45.519809",
     "geom:latitude":45.044186,
     "geom:longitude":111.125813,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DG.OR",
         "wd:id":"Q3874907"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898125,
-    "wof:geomhash":"503948d48a8f0537cf1fd38cf9054a2c",
+    "wof:geomhash":"e1c0e80c84378a364ed68dabb248ebed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092039985,
-    "wof:lastmodified":1690939728,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'rgon",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/204/003/1/1092040031.geojson
+++ b/data/109/204/003/1/1092040031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.796155,
-    "geom:area_square_m":6913220040.240145,
+    "geom:area_square_m":6913220040.239408,
     "geom:bbox":"112.423028648,44.7973177019,113.523261541,46.082394978",
     "geom:latitude":45.392653,
     "geom:longitude":113.043007,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"MN.SB.ON"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898127,
-    "wof:geomhash":"c112554b8fec24ea2d292665fd34769f",
+    "wof:geomhash":"1c1042ed045f493913e91a086eace1c3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1092040031,
-    "wof:lastmodified":1566611691,
+    "wof:lastmodified":1695886844,
     "wof:name":"Ongon",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/204/007/5/1092040075.geojson
+++ b/data/109/204/007/5/1092040075.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MN.BU.OR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898128,
     "wof:geomhash":"b02feda3ee1b139ad6e66619d2f2757e",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092040075,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886368,
     "wof:name":"Orxon",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/204/011/7/1092040117.geojson
+++ b/data/109/204/011/7/1092040117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054725,
-    "geom:area_square_m":437607549.576516,
+    "geom:area_square_m":437607340.873972,
     "geom:bbox":"105.831499,49.519688,106.240385,49.920553",
     "geom:latitude":49.707624,
     "geom:longitude":106.029969,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.DA.OR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898129,
-    "wof:geomhash":"5934266bce10967a8464267e2f35f9b1",
+    "wof:geomhash":"b46985c73bbab31ab44ea2f4999dc50d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092040117,
-    "wof:lastmodified":1627522374,
+    "wof:lastmodified":1695886023,
     "wof:name":"Orxon",
     "wof:parent_id":85674769,
     "wof:placetype":"county",

--- a/data/109/204/014/7/1092040147.geojson
+++ b/data/109/204/014/7/1092040147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159574,
-    "geom:area_square_m":1294229309.2695,
+    "geom:area_square_m":1294229791.677624,
     "geom:bbox":"105.099855,48.810964,105.853551,49.287043",
     "geom:latitude":49.010787,
     "geom:longitude":105.491948,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.SL.OR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898131,
-    "wof:geomhash":"11d0171370dd0120b1efa243b5ae4f81",
+    "wof:geomhash":"dfe65b7c32f81ed17f10ad6cc5f99e9b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092040147,
-    "wof:lastmodified":1627522374,
+    "wof:lastmodified":1695886023,
     "wof:name":"Orxon",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/019/3/1092040193.geojson
+++ b/data/109/204/019/3/1092040193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.362138,
-    "geom:area_square_m":2950284719.798239,
+    "geom:area_square_m":2950284802.469042,
     "geom:bbox":"104.500621,48.531821,105.473186,49.121058",
     "geom:latitude":48.78738,
     "geom:longitude":105.003253,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.SL.OT",
         "wd:id":"Q2748146"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898132,
-    "wof:geomhash":"15afea74e11819ccdfb1f72587062c43",
+    "wof:geomhash":"71889b25ffaea6ee117fbc26b3a33082",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092040193,
-    "wof:lastmodified":1690939718,
+    "wof:lastmodified":1695886844,
     "wof:name":"Orxontuul",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/023/5/1092040235.geojson
+++ b/data/109/204/023/5/1092040235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.67431,
-    "geom:area_square_m":5646786430.240847,
+    "geom:area_square_m":5646786608.006418,
     "geom:bbox":"97.363327,46.590203,98.412067,47.951646",
     "geom:latitude":47.371051,
     "geom:longitude":97.822899,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DZ.OT",
         "wd:id":"Q3403841"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898134,
-    "wof:geomhash":"397ae1b562efef16616b10910a7140d7",
+    "wof:geomhash":"87f96c1fac066cf3dff071a023306223",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092040235,
-    "wof:lastmodified":1690939703,
+    "wof:lastmodified":1695886023,
     "wof:name":"Otgon",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/027/3/1092040273.geojson
+++ b/data/109/204/027/3/1092040273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116355,
-    "geom:area_square_m":973702673.388212,
+    "geom:area_square_m":973702706.109868,
     "geom:bbox":"103.593376,47.236981,104.214112,47.600529",
     "geom:latitude":47.408156,
     "geom:longitude":103.882218,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BU.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898135,
-    "wof:geomhash":"509837b54d502cd5826c3dc947e6da08",
+    "wof:geomhash":"b7bd81b39f0fc83d76b7d1514f68c4be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092040273,
-    "wof:lastmodified":1627522374,
+    "wof:lastmodified":1695886023,
     "wof:name":"Rashaant",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/204/031/5/1092040315.geojson
+++ b/data/109/204/031/5/1092040315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243172,
-    "geom:area_square_m":1965521561.143615,
+    "geom:area_square_m":1965521359.878175,
     "geom:bbox":"100.663483,48.951249,101.674492,49.40932",
     "geom:latitude":49.180535,
     "geom:longitude":101.270213,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HG.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898137,
-    "wof:geomhash":"ae516bab9cf8b24be831e9a22056e974",
+    "wof:geomhash":"f70d488070297902c63031372b27f38c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092040315,
-    "wof:lastmodified":1627522374,
+    "wof:lastmodified":1695886023,
     "wof:name":"Rashaant",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/204/035/5/1092040355.geojson
+++ b/data/109/204/035/5/1092040355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.984794,
-    "geom:area_square_m":7632657984.133314,
+    "geom:area_square_m":7632657564.071146,
     "geom:bbox":"98.740621,50.374288,100.328257,51.776361",
     "geom:latitude":51.184792,
     "geom:longitude":99.729803,
@@ -125,9 +125,10 @@
         "hasc:id":"MN.HG.RE",
         "wd:id":"Q2607950"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898138,
-    "wof:geomhash":"a8886986c82d830ce1f64bb50c8f018b",
+    "wof:geomhash":"e15c34e58a68aab82fbe8e58e2f3898b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1092040355,
-    "wof:lastmodified":1690939720,
+    "wof:lastmodified":1695886844,
     "wof:name":"Renchinlxu'mbe",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/204/039/9/1092040399.geojson
+++ b/data/109/204/039/9/1092040399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.493566,
-    "geom:area_square_m":3899594493.572033,
+    "geom:area_square_m":3899594408.285109,
     "geom:bbox":"90.457633,49.96614,91.990369,50.68201",
     "geom:latitude":50.285604,
     "geom:longitude":91.272987,
@@ -110,9 +110,10 @@
         "hasc:id":"MN.UV.SA",
         "wd:id":"Q3403906"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898140,
-    "wof:geomhash":"5ac5f6703ad98d0b370a8d0803054791",
+    "wof:geomhash":"8abccf2d0ff5032d79c1be12f42258e6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1092040399,
-    "wof:lastmodified":1690939709,
+    "wof:lastmodified":1695886023,
     "wof:name":"Sagil",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/204/041/9/1092040419.geojson
+++ b/data/109/204/041/9/1092040419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.389345,
-    "geom:area_square_m":3190887464.038523,
+    "geom:area_square_m":3190887261.688654,
     "geom:bbox":"88.624922,47.97526,90.025664,49.060015",
     "geom:latitude":48.486291,
     "geom:longitude":89.255967,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.BO.SA",
         "wd:id":"Q2089863"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898141,
-    "wof:geomhash":"7ae772a34909cc436e0aa3cc4f69823c",
+    "wof:geomhash":"985175d6accd7490313e84c0f37cb72b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092040419,
-    "wof:lastmodified":1690939704,
+    "wof:lastmodified":1695886843,
     "wof:name":"Sagsai",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/204/051/3/1092040513.geojson
+++ b/data/109/204/051/3/1092040513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.264234,
-    "geom:area_square_m":2326115391.542594,
+    "geom:area_square_m":2326115346.218947,
     "geom:bbox":"109.527352,44.263843,110.27901,44.988401",
     "geom:latitude":44.607165,
     "geom:longitude":109.938808,
@@ -212,9 +212,10 @@
         "hasc:id":"MN.DG.SZ",
         "wd:id":"Q943290"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898143,
-    "wof:geomhash":"7046bc784860ed96b4d9a505d8fb44d7",
+    "wof:geomhash":"b57b2e57738dda96bda3778e10ec3fe9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -224,7 +225,7 @@
         }
     ],
     "wof:id":1092040513,
-    "wof:lastmodified":1690939722,
+    "wof:lastmodified":1695886845,
     "wof:name":"Sainshand",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/204/057/1/1092040571.geojson
+++ b/data/109/204/057/1/1092040571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.387886,
-    "geom:area_square_m":3345672868.114331,
+    "geom:area_square_m":3345673072.563903,
     "geom:bbox":"105.811004,45.407893,106.924362,46.103636",
     "geom:latitude":45.768557,
     "geom:longitude":106.288566,
@@ -80,9 +80,10 @@
         "hasc:id":"MN.DU.SA",
         "wd:id":"Q7402468"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898150,
-    "wof:geomhash":"1630568ddf042f22fd6f129d5f770a75",
+    "wof:geomhash":"047053bc6afbc17be65ffc9ec8d07a1e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092040571,
-    "wof:lastmodified":1690939721,
+    "wof:lastmodified":1695886023,
     "wof:name":"Saintsagaan",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/204/061/1/1092040611.geojson
+++ b/data/109/204/061/1/1092040611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.46752,
-    "geom:area_square_m":4048057255.963238,
+    "geom:area_square_m":4048057138.794221,
     "geom:bbox":"103.608888,45.15119,104.598334,45.993196",
     "geom:latitude":45.553591,
     "geom:longitude":104.094702,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DU.SO",
         "wd:id":"Q3410096"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898151,
-    "wof:geomhash":"f6cd6f637604634bfeb0408ac8c0926a",
+    "wof:geomhash":"b60fc5e51dd32582de7ada11d79eea2a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092040611,
-    "wof:lastmodified":1690939721,
+    "wof:lastmodified":1695886023,
     "wof:name":"Saixan-Ovoo",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/204/065/7/1092040657.geojson
+++ b/data/109/204/065/7/1092040657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.32986,
-    "geom:area_square_m":2693963968.046395,
+    "geom:area_square_m":2693964403.434113,
     "geom:bbox":"102.158539,48.255386,103.014711,48.939984",
     "geom:latitude":48.663094,
     "geom:longitude":102.538314,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BU.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898153,
-    "wof:geomhash":"4ba78d87536ed7713130769fd3cc5529",
+    "wof:geomhash":"2ea33050266564c28a23ea984e2f48db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092040657,
-    "wof:lastmodified":1627522374,
+    "wof:lastmodified":1695886024,
     "wof:name":"Saixan",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/204/070/5/1092040705.geojson
+++ b/data/109/204/070/5/1092040705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.084694,
-    "geom:area_square_m":9510750054.131153,
+    "geom:area_square_m":9510749732.344849,
     "geom:bbox":"108.394076,44.218486,110.084142,45.343489",
     "geom:latitude":44.837851,
     "geom:longitude":109.234865,
@@ -113,9 +113,10 @@
         "hasc:id":"MN.DG.SD",
         "wd:id":"Q3410079"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898154,
-    "wof:geomhash":"182f4add40837eaae8eea93568f174a8",
+    "wof:geomhash":"80dd9540752430c4824f53657d7120c7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1092040705,
-    "wof:lastmodified":1690939704,
+    "wof:lastmodified":1695886024,
     "wof:name":"Saixandulaan",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/204/074/5/1092040745.geojson
+++ b/data/109/204/074/5/1092040745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161342,
-    "geom:area_square_m":1300556152.816269,
+    "geom:area_square_m":1300556337.871324,
     "geom:bbox":"105.49792,49.048217,105.90701,49.633362",
     "geom:latitude":49.314795,
     "geom:longitude":105.718954,
@@ -105,9 +105,10 @@
         "hasc:id":"MN.SL.SH",
         "wd:id":"Q2748178"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898156,
-    "wof:geomhash":"007644add6bb8405b413d36177fd1f01",
+    "wof:geomhash":"6159103ac16fad2a92fa1f9907290a7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1092040745,
-    "wof:lastmodified":1690939716,
+    "wof:lastmodified":1695886844,
     "wof:name":"Saixan",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/078/3/1092040783.geojson
+++ b/data/109/204/078/3/1092040783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.293813,
-    "geom:area_square_m":2403608004.839311,
+    "geom:area_square_m":2403607950.098941,
     "geom:bbox":"94.63681,48.346395,95.648497,48.850377",
     "geom:latitude":48.578265,
     "geom:longitude":95.14072,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DZ.SA",
         "wd:id":"Q3402132"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898157,
-    "wof:geomhash":"9ee07578efb759642ebc7ab69fc1f2e8",
+    "wof:geomhash":"ff889d61e858faad7aa2fd5563b7f137",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092040783,
-    "wof:lastmodified":1690939706,
+    "wof:lastmodified":1695886024,
     "wof:name":"Santmargac",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/082/7/1092040827.geojson
+++ b/data/109/204/082/7/1092040827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.30494,
-    "geom:area_square_m":2618192496.313841,
+    "geom:area_square_m":2618192658.017687,
     "geom:bbox":"103.278821,45.718094,104.297111,46.253488",
     "geom:latitude":46.023425,
     "geom:longitude":103.829505,
@@ -92,9 +92,10 @@
         "hasc:id":"MN.OH.SA",
         "wd:id":"Q3403754"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898159,
-    "wof:geomhash":"f5b8c02633bdcf240e7ff7cedd744695",
+    "wof:geomhash":"cc5e9f65fefa8e85e63d25661bfe28a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092040827,
-    "wof:lastmodified":1690939705,
+    "wof:lastmodified":1695886024,
     "wof:name":"Sant",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/204/086/5/1092040865.geojson
+++ b/data/109/204/086/5/1092040865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.168772,
-    "geom:area_square_m":1358469466.797476,
+    "geom:area_square_m":1358469074.288789,
     "geom:bbox":"105.110495,49.120042,105.614356,49.634277",
     "geom:latitude":49.386509,
     "geom:longitude":105.34047,
@@ -89,9 +89,10 @@
         "hasc:id":"MN.SL.ST",
         "wd:id":"Q2748175"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898160,
-    "wof:geomhash":"00a86f3caa13064de74a4fec0b8f74d7",
+    "wof:geomhash":"5f2fd06f85ce8aa4c07b4a2ef5c903d1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1092040865,
-    "wof:lastmodified":1690939718,
+    "wof:lastmodified":1695886844,
     "wof:name":"Sant",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/091/3/1092040913.geojson
+++ b/data/109/204/091/3/1092040913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.607696,
-    "geom:area_square_m":4858950188.106344,
+    "geom:area_square_m":4858949737.246664,
     "geom:bbox":"103.624483,49.102327,104.78046,50.312383",
     "geom:latitude":49.711546,
     "geom:longitude":104.17391,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.BU.SE",
         "wd:id":"Q2606063"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898162,
-    "wof:geomhash":"f1988b324b9ff3058d3b77ad273eb56e",
+    "wof:geomhash":"388351fad0677947c7c7edda9e60bc65",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092040913,
-    "wof:lastmodified":1690939706,
+    "wof:lastmodified":1695886843,
     "wof:name":"Selenge",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/204/096/1/1092040961.geojson
+++ b/data/109/204/096/1/1092040961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.509155,
-    "geom:area_square_m":4160550490.195018,
+    "geom:area_square_m":4160550721.217708,
     "geom:bbox":"113.624442,48.190847,114.554068,49.079008",
     "geom:latitude":48.635276,
     "geom:longitude":114.108153,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DD.SE",
         "wd:id":"Q3410035"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898163,
-    "wof:geomhash":"feb9e133a015147193844f6bd7202a0b",
+    "wof:geomhash":"694c0d8d46f8034647be0a9e13948180",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092040961,
-    "wof:lastmodified":1690939706,
+    "wof:lastmodified":1695886024,
     "wof:name":"Sergelen",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/204/100/3/1092041003.geojson
+++ b/data/109/204/100/3/1092041003.geojson
@@ -85,6 +85,7 @@
         "hasc:id":"MN.TO.SE",
         "wd:id":"Q3396295"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898164,
     "wof:geomhash":"3e3bc4f7d9c92627e6dc6a0519122ee6",
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092041003,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886024,
     "wof:name":"Sergelen",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/204/103/5/1092041035.geojson
+++ b/data/109/204/103/5/1092041035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.916948,
-    "geom:area_square_m":8187430006.007954,
+    "geom:area_square_m":8187429783.931617,
     "geom:bbox":"101.741258,43.259264,103.019596,44.186037",
     "geom:latitude":43.770758,
     "geom:longitude":102.398902,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.OG.SE",
         "wd:id":"Q3403897"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898166,
-    "wof:geomhash":"d144487ac0886fdc5ccf92f4bf788fe1",
+    "wof:geomhash":"5e4e13702b784b10aaf04e3a4d4521e6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092041035,
-    "wof:lastmodified":1690939701,
+    "wof:lastmodified":1695886024,
     "wof:name":"Sevrei",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/204/108/1/1092041081.geojson
+++ b/data/109/204/108/1/1092041081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083507,
-    "geom:area_square_m":663164102.042549,
+    "geom:area_square_m":663164054.766112,
     "geom:bbox":"106.022305,49.87693,106.46009,50.191758",
     "geom:latitude":50.041167,
     "geom:longitude":106.243451,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.SL.SM",
         "wd:id":"Q3397359"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898167,
-    "wof:geomhash":"400588068c099512fd6e036f6d3a4acc",
+    "wof:geomhash":"531455f7248d431e5a8b6fcf8262beda",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092041081,
-    "wof:lastmodified":1690939714,
+    "wof:lastmodified":1695886844,
     "wof:name":"Shaamar",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/112/3/1092041123.geojson
+++ b/data/109/204/112/3/1092041123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.669195,
-    "geom:area_square_m":5697601365.693988,
+    "geom:area_square_m":5697601840.259827,
     "geom:bbox":"94.575431,46.12836,96.012493,46.845843",
     "geom:latitude":46.484005,
     "geom:longitude":95.265646,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.GA.SH",
         "wd:id":"Q3404335"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898169,
-    "wof:geomhash":"951472508f600ff5be6f5d89658cb039",
+    "wof:geomhash":"6b8e466bf8ca42ef84ed5094a384ab54",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092041123,
-    "wof:lastmodified":1690939722,
+    "wof:lastmodified":1695886024,
     "wof:name":"Sharga",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/204/115/9/1092041159.geojson
+++ b/data/109/204/115/9/1092041159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011966,
-    "geom:area_square_m":96624009.774499,
+    "geom:area_square_m":96624047.185048,
     "geom:bbox":"106.379396,49.174729,106.532744,49.291954",
     "geom:latitude":49.228793,
     "geom:longitude":106.46079,
@@ -113,9 +113,10 @@
         "hasc:id":"MN.DA.SH",
         "wd:id":"Q2667639"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898170,
-    "wof:geomhash":"15af8b1500470edafbe0a68fbbc82b09",
+    "wof:geomhash":"6b238cf3cb615f216b3bc0cf6b08b834",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1092041159,
-    "wof:lastmodified":1690939723,
+    "wof:lastmodified":1695886024,
     "wof:name":"Sharyngol",
     "wof:parent_id":85674769,
     "wof:placetype":"county",

--- a/data/109/204/120/5/1092041205.geojson
+++ b/data/109/204/120/5/1092041205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.360154,
-    "geom:area_square_m":3040992754.93988,
+    "geom:area_square_m":3040992586.167479,
     "geom:bbox":"96.792755,46.565857,97.523654,47.37637",
     "geom:latitude":46.932801,
     "geom:longitude":97.195136,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.DZ.SH",
         "wd:id":"Q3402266"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898172,
-    "wof:geomhash":"086075796d8b8b9ee7bd0e17c66a840a",
+    "wof:geomhash":"06463edffeea689c32aef15b790a15ec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092041205,
-    "wof:lastmodified":1690939710,
+    "wof:lastmodified":1695886024,
     "wof:name":"Shilu'ustei",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/122/7/1092041227.geojson
+++ b/data/109/204/122/7/1092041227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.254497,
-    "geom:area_square_m":2063067470.623796,
+    "geom:area_square_m":2063067091.495975,
     "geom:bbox":"99.094371,48.827654,100.072792,49.250119",
     "geom:latitude":49.035806,
     "geom:longitude":99.511768,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.HG.SI",
         "wd:id":"Q2607747"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898173,
-    "wof:geomhash":"8e8a90b0964cf938e211fd635368cf22",
+    "wof:geomhash":"27f25c20a73bd51a2fc1712219d23f2b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092041227,
-    "wof:lastmodified":1690939724,
+    "wof:lastmodified":1695886845,
     "wof:name":"Shine-Ider",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/204/124/9/1092041249.geojson
+++ b/data/109/204/124/9/1092041249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.838403,
-    "geom:area_square_m":16435721490.716743,
+    "geom:area_square_m":16435721693.5429,
     "geom:bbox":"98.605516,42.565788,99.990784,44.903406",
     "geom:latitude":43.692084,
     "geom:longitude":99.199965,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.BH.SN",
         "wd:id":"Q2093519"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898178,
-    "wof:geomhash":"713b10c7e7b73f5e7eb943daf5229336",
+    "wof:geomhash":"3b4dc89a23f88abee394337e42620fb3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092041249,
-    "wof:lastmodified":1690939723,
+    "wof:lastmodified":1695886025,
     "wof:name":"Shinejinst",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/204/129/5/1092041295.geojson
+++ b/data/109/204/129/5/1092041295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104719,
-    "geom:area_square_m":898519072.242579,
+    "geom:area_square_m":898519196.790183,
     "geom:bbox":"108.216998,45.882688,108.745812,46.284249",
     "geom:latitude":46.059878,
     "geom:longitude":108.515357,
@@ -89,9 +89,10 @@
         "hasc:id":"MN.GS.SH",
         "wd:id":"Q2093470"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898180,
-    "wof:geomhash":"a375f353f4bd5475df26e9cac91406a7",
+    "wof:geomhash":"eaeccd20651c84b775d312dd0528cce0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1092041295,
-    "wof:lastmodified":1690939710,
+    "wof:lastmodified":1695886025,
     "wof:name":"Shiveegovi",
     "wof:parent_id":85674779,
     "wof:placetype":"county",

--- a/data/109/204/132/3/1092041323.geojson
+++ b/data/109/204/132/3/1092041323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145399,
-    "geom:area_square_m":1201419744.66996,
+    "geom:area_square_m":1201419965.678471,
     "geom:bbox":"106.366278,47.846677,106.874291,48.27025",
     "geom:latitude":48.068446,
     "geom:longitude":106.643479,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.UB.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898181,
-    "wof:geomhash":"2bd3ecb44632b54bfa1d34cd4acc83ab",
+    "wof:geomhash":"5d9ad261df61dfa5bc03c7e5bf063feb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092041323,
-    "wof:lastmodified":1627522375,
+    "wof:lastmodified":1695886025,
     "wof:name":"Songinoxairxan",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/204/136/7/1092041367.geojson
+++ b/data/109/204/136/7/1092041367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298035,
-    "geom:area_square_m":2418301106.253175,
+    "geom:area_square_m":2418301252.887331,
     "geom:bbox":"95.426264,48.727804,96.26244,49.250986",
     "geom:latitude":48.988481,
     "geom:longitude":95.841634,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DZ.SO",
         "wd:id":"Q3403993"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898183,
-    "wof:geomhash":"034aee88191dca630a700d0bfeaef692",
+    "wof:geomhash":"786ba0861416d47189daba0710477c39",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092041367,
-    "wof:lastmodified":1690939712,
+    "wof:lastmodified":1695886025,
     "wof:name":"Songino",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/140/7/1092041407.geojson
+++ b/data/109/204/140/7/1092041407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.439535,
-    "geom:area_square_m":3740448127.988245,
+    "geom:area_square_m":3740448034.339782,
     "geom:bbox":"108.143995,46.004292,109.115129,46.999113",
     "geom:latitude":46.509962,
     "geom:longitude":108.649667,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.GS.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898184,
-    "wof:geomhash":"f2cb5d9fb99ac32ab3e95bcfe7b2d417",
+    "wof:geomhash":"a9b5981601d199d794b352da67c5c648",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092041407,
-    "wof:lastmodified":1627522376,
+    "wof:lastmodified":1695886025,
     "wof:name":"Su'mber",
     "wof:parent_id":85674779,
     "wof:placetype":"county",

--- a/data/109/204/143/9/1092041439.geojson
+++ b/data/109/204/143/9/1092041439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04303,
-    "geom:area_square_m":350354656.487746,
+    "geom:area_square_m":350354747.18671,
     "geom:bbox":"105.620061,48.71801,106.071778,48.889294",
     "geom:latitude":48.817293,
     "geom:longitude":105.880661,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.TO.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898185,
-    "wof:geomhash":"8538fbc05f5457cb742102f2ece2bef8",
+    "wof:geomhash":"6f6824ddb6e1aec1a3ca57d852b05afa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092041439,
-    "wof:lastmodified":1627522376,
+    "wof:lastmodified":1695886025,
     "wof:name":"Su'mber",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/204/147/7/1092041477.geojson
+++ b/data/109/204/147/7/1092041477.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MN.SL.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898187,
     "wof:geomhash":"3f85e4b44eeb5abacbfae7f9aaefae51",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092041477,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886404,
     "wof:name":"Su'xbaatar",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/152/1/1092041521.geojson
+++ b/data/109/204/152/1/1092041521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026294,
-    "geom:area_square_m":217216146.139489,
+    "geom:area_square_m":217216149.738559,
     "geom:bbox":"106.864278,47.903823,107.035287,48.196028",
     "geom:latitude":48.080027,
     "geom:longitude":106.950578,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.UB.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898188,
-    "wof:geomhash":"59109b5446ef3f3fad6503428cb3c423",
+    "wof:geomhash":"6db98484d3b23ef335fd01f42ef56bf7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092041521,
-    "wof:lastmodified":1627522376,
+    "wof:lastmodified":1695886025,
     "wof:name":"Su'xbaatar",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/204/156/7/1092041567.geojson
+++ b/data/109/204/156/7/1092041567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.438956,
-    "geom:area_square_m":3729981868.917397,
+    "geom:area_square_m":3729981678.813228,
     "geom:bbox":"95.924152,46.212627,96.990395,46.957512",
     "geom:latitude":46.590663,
     "geom:longitude":96.480709,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"MN.GA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898190,
-    "wof:geomhash":"073a7efb9877123476f96ac98a1edc1a",
+    "wof:geomhash":"d9a656782d7318ecec3c8a11e5249dd5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1092041567,
-    "wof:lastmodified":1627522376,
+    "wof:lastmodified":1695886025,
     "wof:name":"Taishir",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/204/160/1/1092041601.geojson
+++ b/data/109/204/160/1/1092041601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.408734,
-    "geom:area_square_m":3502715561.181336,
+    "geom:area_square_m":3502714803.43314,
     "geom:bbox":"102.240603,45.711154,103.173916,46.469646",
     "geom:latitude":46.127872,
     "geom:longitude":102.695648,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.OH.TA",
         "wd:id":"Q3403786"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898191,
-    "wof:geomhash":"8716c1f32015208cf5147e67e6ddfac6",
+    "wof:geomhash":"d4247b471e23777ea924bbb13a41f2be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092041601,
-    "wof:lastmodified":1690939702,
+    "wof:lastmodified":1695886025,
     "wof:name":"Taragt",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/204/165/1/1092041651.geojson
+++ b/data/109/204/165/1/1092041651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.475499,
-    "geom:area_square_m":3799124904.876752,
+    "geom:area_square_m":3799124974.632601,
     "geom:bbox":"91.259918,49.304849,92.498173,50.184003",
     "geom:latitude":49.747781,
     "geom:longitude":91.863447,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.UV.TA",
         "wd:id":"Q7686004"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898193,
-    "wof:geomhash":"c4415bf83cd9577bb6046a8ae2294d3b",
+    "wof:geomhash":"f077af1dd8bf5d3a1d2f85d8cf08dbec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092041651,
-    "wof:lastmodified":1690939712,
+    "wof:lastmodified":1695886025,
     "wof:name":"Tarialan",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/204/169/5/1092041695.geojson
+++ b/data/109/204/169/5/1092041695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.426353,
-    "geom:area_square_m":3411835432.551146,
+    "geom:area_square_m":3411835657.48173,
     "geom:bbox":"101.668768,49.26059,102.752031,50.05336",
     "geom:latitude":49.671341,
     "geom:longitude":102.0857,
@@ -116,9 +116,10 @@
         "hasc:id":"MN.HG.TA",
         "wd:id":"Q2607986"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898194,
-    "wof:geomhash":"ab077d1f011f6e7c800ccbe8d7bdd14d",
+    "wof:geomhash":"fd7b5409562ce12e91a264cab566af42",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1092041695,
-    "wof:lastmodified":1690939702,
+    "wof:lastmodified":1695886843,
     "wof:name":"Tarialan",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/204/172/7/1092041727.geojson
+++ b/data/109/204/172/7/1092041727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.493201,
-    "geom:area_square_m":4063148841.429075,
+    "geom:area_square_m":4063148992.472919,
     "geom:bbox":"99.06098,47.954588,100.567835,48.528886",
     "geom:latitude":48.221502,
     "geom:longitude":99.858508,
@@ -128,9 +128,10 @@
         "hasc:id":"MN.AR.TA",
         "wd:id":"Q1025040"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898196,
-    "wof:geomhash":"64a8541a359ff684e03790965fba1b20",
+    "wof:geomhash":"a6ee211733f145d74cece29e0487a033",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092041727,
-    "wof:lastmodified":1690939711,
+    "wof:lastmodified":1695886844,
     "wof:name":"Tariat",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/204/177/1/1092041771.geojson
+++ b/data/109/204/177/1/1092041771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.423115,
-    "geom:area_square_m":3447130453.658625,
+    "geom:area_square_m":3447130771.446176,
     "geom:bbox":"97.033199,48.354687,97.943068,49.214372",
     "geom:latitude":48.786052,
     "geom:longitude":97.576217,
@@ -92,9 +92,10 @@
         "hasc:id":"MN.DZ.TM",
         "wd:id":"Q3403868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898197,
-    "wof:geomhash":"7726d95a4194f61df47f70684a3e4470",
+    "wof:geomhash":"afb7ed623bbabafcdf27a355601da0e4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092041771,
-    "wof:lastmodified":1690939723,
+    "wof:lastmodified":1695886026,
     "wof:name":"Telmen",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/181/5/1092041815.geojson
+++ b/data/109/204/181/5/1092041815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.969726,
-    "geom:area_square_m":7707423215.280598,
+    "geom:area_square_m":7707423283.756363,
     "geom:bbox":"102.048771,49.656506,104.026719,50.439279",
     "geom:latitude":50.000719,
     "geom:longitude":103.078725,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BU.TE",
         "wd:id":"Q2606122"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898198,
-    "wof:geomhash":"ba17f3d79c4b00577b1958230445beeb",
+    "wof:geomhash":"c84299d573adc31f48b9328c538cfb51",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092041815,
-    "wof:lastmodified":1690939711,
+    "wof:lastmodified":1695886026,
     "wof:name":"Teshig",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/204/185/3/1092041853.geojson
+++ b/data/109/204/185/3/1092041853.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MN.UV.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898200,
     "wof:geomhash":"bec06402d8c792ee1b6032decd57fa3f",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092041853,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886411,
     "wof:name":"Tes",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/204/189/7/1092041897.geojson
+++ b/data/109/204/189/7/1092041897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115397,
-    "geom:area_square_m":924592955.587545,
+    "geom:area_square_m":924593372.902216,
     "geom:bbox":"95.38023,49.375293,95.831134,49.830734",
     "geom:latitude":49.611047,
     "geom:longitude":95.594522,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.DZ.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898202,
-    "wof:geomhash":"211b6216706b745d7411376c1049a858",
+    "wof:geomhash":"c624fc37d5307fed97e8279a2baab6d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092041897,
-    "wof:lastmodified":1627522376,
+    "wof:lastmodified":1695886026,
     "wof:name":"Tes",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/192/3/1092041923.geojson
+++ b/data/109/204/192/3/1092041923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.626811,
-    "geom:area_square_m":5401482870.824541,
+    "geom:area_square_m":5401482079.840452,
     "geom:bbox":"94.211759,45.25903,95.432858,46.199306",
     "geom:latitude":45.820224,
     "geom:longitude":94.851385,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.GA.TG",
         "wd:id":"Q3404055"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898203,
-    "wof:geomhash":"74711140d65ec1da6ff374655e00fabc",
+    "wof:geomhash":"d39239784c919c0813df1529b5e157a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092041923,
-    "wof:lastmodified":1690939701,
+    "wof:lastmodified":1695886027,
     "wof:name":"To'grog",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/204/196/3/1092041963.geojson
+++ b/data/109/204/196/3/1092041963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.625494,
-    "geom:area_square_m":5443059471.019406,
+    "geom:area_square_m":5443059490.428073,
     "geom:bbox":"102.673799,44.822762,103.789384,45.775659",
     "geom:latitude":45.270899,
     "geom:longitude":103.161954,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.OH.TO",
         "wd:id":"Q3403937"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898205,
-    "wof:geomhash":"4c7262729e4c2c00878f9f01f3b5cf10",
+    "wof:geomhash":"6dd63654f4f5eeaaa402a6126bada6d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092041963,
-    "wof:lastmodified":1690939711,
+    "wof:lastmodified":1695886027,
     "wof:name":"To'grog",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/204/197/9/1092041979.geojson
+++ b/data/109/204/197/9/1092041979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.311374,
-    "geom:area_square_m":2512187515.86227,
+    "geom:area_square_m":2512187749.73247,
     "geom:bbox":"99.72953,49.030938,100.69607,49.50053",
     "geom:latitude":49.270949,
     "geom:longitude":100.207442,
@@ -125,9 +125,10 @@
         "hasc:id":"MN.HG.TM",
         "wd:id":"Q2607735"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898206,
-    "wof:geomhash":"1794f4815ae9eca12cc560c4e736a6ca",
+    "wof:geomhash":"68d44ab3e68774f5363c93d55651956f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1092041979,
-    "wof:lastmodified":1690939713,
+    "wof:lastmodified":1695886844,
     "wof:name":"To'morbulag",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/204/202/1/1092042021.geojson
+++ b/data/109/204/202/1/1092042021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142289,
-    "geom:area_square_m":1190243688.500644,
+    "geom:area_square_m":1190243603.007952,
     "geom:bbox":"101.78168,47.12574,102.34143,47.713472",
     "geom:latitude":47.429623,
     "geom:longitude":102.063696,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.AR.TU",
         "wd:id":"Q1025028"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898208,
-    "wof:geomhash":"bb79e1df88ecaac3f2eeb17b93746e6a",
+    "wof:geomhash":"29f1ee448922f12e580e2ade66f53e56",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092042021,
-    "wof:lastmodified":1690939709,
+    "wof:lastmodified":1695886028,
     "wof:name":"To'vshru'ulex",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/204/207/9/1092042079.geojson
+++ b/data/109/204/207/9/1092042079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.361421,
-    "geom:area_square_m":2967288123.850345,
+    "geom:area_square_m":2967288239.120199,
     "geom:bbox":"89.899097,48.084773,90.851108,48.683001",
     "geom:latitude":48.396869,
     "geom:longitude":90.371356,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.BO.TO",
         "wd:id":"Q2429961"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898210,
-    "wof:geomhash":"2cb0d825c3056151794b4c94c756adac",
+    "wof:geomhash":"dbb66a6a17383fa7881a59277d63a93c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092042079,
-    "wof:lastmodified":1690939720,
+    "wof:lastmodified":1695886844,
     "wof:name":"Tolbo",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/204/210/7/1092042107.geojson
+++ b/data/109/204/210/7/1092042107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.876763,
-    "geom:area_square_m":7549719090.566514,
+    "geom:area_square_m":7549719363.760677,
     "geom:bbox":"93.100193,44.955826,94.435686,46.635236",
     "geom:latitude":45.861379,
     "geom:longitude":93.682347,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.GA.TH",
         "wd:id":"Q3404388"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898211,
-    "wof:geomhash":"9ea4245b4ea185a91cc2410b517d660a",
+    "wof:geomhash":"9865b036c04d8de910637ec7b2a1c87f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092042107,
-    "wof:lastmodified":1690939705,
+    "wof:lastmodified":1695886028,
     "wof:name":"Tonkhil",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/204/214/9/1092042149.geojson
+++ b/data/109/204/214/9/1092042149.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"MN.HG.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898213,
     "wof:geomhash":"cc53f15d955e09d3dc5677a03df5e1c5",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092042149,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886414,
     "wof:name":"Tosoncengel",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/204/219/7/1092042197.geojson
+++ b/data/109/204/219/7/1092042197.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1092042197,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886414,
     "wof:name":"Tosoncengel",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/223/1/1092042231.geojson
+++ b/data/109/204/223/1/1092042231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.32837,
-    "geom:area_square_m":2666653967.750444,
+    "geom:area_square_m":2666653674.888488,
     "geom:bbox":"96.111354,48.41945,96.855936,49.290016",
     "geom:latitude":48.946823,
     "geom:longitude":96.470888,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DZ.TT",
         "wd:id":"Q3402401"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898216,
-    "wof:geomhash":"2883a233f5d83b0446a1c0651a9adfd3",
+    "wof:geomhash":"ed01b1ee07ff64fd6b4f70d558585645",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092042231,
-    "wof:lastmodified":1690939716,
+    "wof:lastmodified":1695886028,
     "wof:name":"Tu'devtei",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/226/9/1092042269.geojson
+++ b/data/109/204/226/9/1092042269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25574,
-    "geom:area_square_m":2134216319.912626,
+    "geom:area_square_m":2134216766.526982,
     "geom:bbox":"112.075966,47.308924,112.723848,47.825797",
     "geom:latitude":47.55355,
     "geom:longitude":112.410927,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.SB.TT",
         "wd:id":"Q3402392"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898217,
-    "wof:geomhash":"73bf074219fd734f19b1da9a42e7bd36",
+    "wof:geomhash":"56fbf40046ec8cfee2c5f703e1dee729",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092042269,
-    "wof:lastmodified":1690939705,
+    "wof:lastmodified":1695886028,
     "wof:name":"Tu'mencogt",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/204/231/7/1092042317.geojson
+++ b/data/109/204/231/7/1092042317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.443904,
-    "geom:area_square_m":3540836407.945043,
+    "geom:area_square_m":3540836197.271177,
     "geom:bbox":"100.043387,49.42726,101.377691,50.111685",
     "geom:latitude":49.827919,
     "geom:longitude":100.672569,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.HG.TU",
         "wd:id":"Q2607922"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898218,
-    "wof:geomhash":"68b7e90f042471051cb1e3a03a229575",
+    "wof:geomhash":"4ab6747051614253045b2d6a39fb2a5c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092042317,
-    "wof:lastmodified":1690939719,
+    "wof:lastmodified":1695886844,
     "wof:name":"Tu'nel",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/204/235/9/1092042359.geojson
+++ b/data/109/204/235/9/1092042359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263497,
-    "geom:area_square_m":2093163618.593791,
+    "geom:area_square_m":2093163140.321028,
     "geom:bbox":"90.920378,49.781858,92.064961,50.276359",
     "geom:latitude":50.026605,
     "geom:longitude":91.516439,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.UV.TU",
         "wd:id":"Q3402283"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898220,
-    "wof:geomhash":"40675151d9bf75f5f77ea491a916afb8",
+    "wof:geomhash":"d6b9f88fced485a124cbcf4472bf7c3e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092042359,
-    "wof:lastmodified":1690939707,
+    "wof:lastmodified":1695886028,
     "wof:name":"Tu'rgen",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/204/238/9/1092042389.geojson
+++ b/data/109/204/238/9/1092042389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.323086,
-    "geom:area_square_m":2552372979.074148,
+    "geom:area_square_m":2552372677.101484,
     "geom:bbox":"104.43562,50.012687,106.140802,50.479269",
     "geom:latitude":50.290955,
     "geom:longitude":105.193412,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.SL.TU",
         "wd:id":"Q2748135"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898221,
-    "wof:geomhash":"3318db9da67f443dd4170973f1068434",
+    "wof:geomhash":"9123ea6fe6ea788dbfb66db09af3b322",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092042389,
-    "wof:lastmodified":1690939719,
+    "wof:lastmodified":1695886844,
     "wof:name":"Tu'shig",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/243/7/1092042437.geojson
+++ b/data/109/204/243/7/1092042437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.513907,
-    "geom:area_square_m":4388656691.68994,
+    "geom:area_square_m":4388656756.475451,
     "geom:bbox":"111.220893,45.798867,112.169786,46.782075",
     "geom:latitude":46.319498,
     "geom:longitude":111.692897,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.SB.TS",
         "wd:id":"Q3403832"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898223,
-    "wof:geomhash":"df95df1a235e3a7eda6ebd200227b1d5",
+    "wof:geomhash":"8f317bfca0769f43a9d473c49689d452",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092042437,
-    "wof:lastmodified":1690939705,
+    "wof:lastmodified":1695886029,
     "wof:name":"Tu'vshinshiree",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/204/248/1/1092042481.geojson
+++ b/data/109/204/248/1/1092042481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.860098,
-    "geom:area_square_m":7402058499.229876,
+    "geom:area_square_m":7402058344.409463,
     "geom:bbox":"91.243354,45.062033,92.332579,46.692761",
     "geom:latitude":45.891953,
     "geom:longitude":91.806866,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.HD.UE",
         "wd:id":"Q3404181"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898224,
-    "wof:geomhash":"01490229525896ef645d4c4d2fad24bc",
+    "wof:geomhash":"b955161eed5acae051603854d08f0d13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092042481,
-    "wof:lastmodified":1690939715,
+    "wof:lastmodified":1695886844,
     "wof:name":"U'yench",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/204/251/5/1092042515.geojson
+++ b/data/109/204/251/5/1092042515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187431,
-    "geom:area_square_m":1545252417.36143,
+    "geom:area_square_m":1545252205.919249,
     "geom:bbox":"105.038132,47.974299,105.768707,48.427511",
     "geom:latitude":48.183975,
     "geom:longitude":105.395425,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.TO.UG",
         "wd:id":"Q3396365"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898226,
-    "wof:geomhash":"ecb8ed04a344cce4f06801c6bb4d9aac",
+    "wof:geomhash":"aad6df5af6bec6a206460dcc768dbfad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092042515,
-    "wof:lastmodified":1690939708,
+    "wof:lastmodified":1695886029,
     "wof:name":"Ugtaalcaidam",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/204/255/7/1092042557.geojson
+++ b/data/109/204/255/7/1092042557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.286001,
-    "geom:area_square_m":10032633009.669136,
+    "geom:area_square_m":10032632278.398367,
     "geom:bbox":"97.823064,50.277654,99.771539,51.476297",
     "geom:latitude":50.881664,
     "geom:longitude":98.73237,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.HG.UU",
         "wd:id":"Q2607717"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898227,
-    "wof:geomhash":"43ffaed049977a36b4aa8ca024008c3f",
+    "wof:geomhash":"f34e11b6ae0389ac0bf5607082d81d32",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092042557,
-    "wof:lastmodified":1690939722,
+    "wof:lastmodified":1695886845,
     "wof:name":"Ulaan uul",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/204/260/9/1092042609.geojson
+++ b/data/109/204/260/9/1092042609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.303608,
-    "geom:area_square_m":11614634653.47447,
+    "geom:area_square_m":11614635061.137821,
     "geom:bbox":"109.15286,43.281321,111.440266,44.591443",
     "geom:latitude":43.900247,
     "geom:longitude":110.278718,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DG.UB",
         "wd:id":"Q3410077"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898229,
-    "wof:geomhash":"f19b18e7499230e20460e907bf21aecd",
+    "wof:geomhash":"d605a62fa0a4b3ada8be5ef5b2ebb7ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092042609,
-    "wof:lastmodified":1690939707,
+    "wof:lastmodified":1695886029,
     "wof:name":"Ulaanbadrax",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/204/264/9/1092042649.geojson
+++ b/data/109/204/264/9/1092042649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.740158,
-    "geom:area_square_m":5991308043.778498,
+    "geom:area_square_m":5991308280.78193,
     "geom:bbox":"87.812034,48.204838,89.836789,49.557974",
     "geom:latitude":49.10761,
     "geom:longitude":88.927575,
@@ -125,9 +125,10 @@
         "hasc:id":"MN.BO.UH",
         "wd:id":"Q2089793"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898230,
-    "wof:geomhash":"9762d8a489c298a5185fe3db9065e123",
+    "wof:geomhash":"156cb5e64f66059ea1f776f4d02392c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1092042649,
-    "wof:lastmodified":1690939721,
+    "wof:lastmodified":1695886844,
     "wof:name":"Ulaanxus",
     "wof:parent_id":85674705,
     "wof:placetype":"county",

--- a/data/109/204/268/3/1092042683.geojson
+++ b/data/109/204/268/3/1092042683.geojson
@@ -141,6 +141,7 @@
     "wof:concordances":{
         "hasc:id":"MN.DZ.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898232,
     "wof:geomhash":"d83c2a374d79f74886ac8aceac7e8185",
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1092042683,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886844,
     "wof:name":"Uliastai",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/272/7/1092042727.geojson
+++ b/data/109/204/272/7/1092042727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.427346,
-    "geom:area_square_m":3500785778.708385,
+    "geom:area_square_m":3500785869.865809,
     "geom:bbox":"93.636576,48.119509,94.689497,48.807009",
     "geom:latitude":48.509148,
     "geom:longitude":94.210715,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.DZ.UR",
         "wd:id":"Q3402239"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898233,
-    "wof:geomhash":"4064b0c8e15a69bb23dbc0ed27340cc3",
+    "wof:geomhash":"2b0eb00da20fd369f9bf388ebd330d09",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092042727,
-    "wof:lastmodified":1690939706,
+    "wof:lastmodified":1695886029,
     "wof:name":"Urgamal",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/277/7/1092042777.geojson
+++ b/data/109/204/277/7/1092042777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.583135,
-    "geom:area_square_m":4956941579.673172,
+    "geom:area_square_m":4956942059.952463,
     "geom:bbox":"111.813479,46.09347,113.059824,46.913378",
     "geom:latitude":46.570838,
     "geom:longitude":112.39031,
@@ -95,9 +95,10 @@
         "hasc:id":"MN.SB.UU",
         "wd:id":"Q3403882"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898235,
-    "wof:geomhash":"6a0d61bf7e614566042f87e57dc97a6d",
+    "wof:geomhash":"36e2e0e22b50cbd944c99d17f64a3f7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092042777,
-    "wof:lastmodified":1690939715,
+    "wof:lastmodified":1695886029,
     "wof:name":"Uulbayan",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/204/280/3/1092042803.geojson
+++ b/data/109/204/280/3/1092042803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.356918,
-    "geom:area_square_m":3041984583.410503,
+    "geom:area_square_m":3041984776.724557,
     "geom:bbox":"101.468684,46.090205,102.4332,46.729712",
     "geom:latitude":46.427677,
     "geom:longitude":101.931004,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.OH.UY",
         "wd:id":"Q3403953"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898236,
-    "wof:geomhash":"792b6ff5fee977c0372b3ea8cc422691",
+    "wof:geomhash":"6b22beaa02618847d86a598bf4687c8d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092042803,
-    "wof:lastmodified":1690939703,
+    "wof:lastmodified":1695886029,
     "wof:name":"Uyanga",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/204/284/7/1092042847.geojson
+++ b/data/109/204/284/7/1092042847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318087,
-    "geom:area_square_m":2603132396.855739,
+    "geom:area_square_m":2603132830.401776,
     "geom:bbox":"101.606948,48.226631,102.372762,48.898707",
     "geom:latitude":48.559803,
     "geom:longitude":101.970099,
@@ -119,9 +119,10 @@
         "hasc:id":"MN.AR.HH",
         "wd:id":"Q2089868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898238,
-    "wof:geomhash":"cb0808787b78e3e0d0f44e9c4eade484",
+    "wof:geomhash":"37d2656626b0d9bf4d96ca41c4a31e63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092042847,
-    "wof:lastmodified":1690939715,
+    "wof:lastmodified":1695886029,
     "wof:name":"Xairxan",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/204/289/7/1092042897.geojson
+++ b/data/109/204/289/7/1092042897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.478803,
-    "geom:area_square_m":4124024956.973914,
+    "geom:area_square_m":4124025311.999823,
     "geom:bbox":"101.666397,45.385242,102.52341,46.291809",
     "geom:latitude":45.847257,
     "geom:longitude":102.08786,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.OH.HD",
         "wd:id":"Q3403891"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898239,
-    "wof:geomhash":"586dbd268e6e08cac4a9fcb54c887597",
+    "wof:geomhash":"b3347418026dc2ea4dd6e75fb7bdf626",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092042897,
-    "wof:lastmodified":1690939704,
+    "wof:lastmodified":1695886029,
     "wof:name":"Xairxandulaan",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/204/293/7/1092042937.geojson
+++ b/data/109/204/293/7/1092042937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.599865,
-    "geom:area_square_m":5154844689.256938,
+    "geom:area_square_m":5154845316.877081,
     "geom:bbox":"95.266369,45.6834,96.811092,46.350169",
     "geom:latitude":45.975631,
     "geom:longitude":96.027785,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.GA.HA",
         "wd:id":"Q3410082"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898241,
-    "wof:geomhash":"033d1554395645cf3cf6e067fdff4a22",
+    "wof:geomhash":"89275917abebff1b6c0b5c73e54b7674",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092042937,
-    "wof:lastmodified":1690939708,
+    "wof:lastmodified":1695886029,
     "wof:name":"Xaliun",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/204/297/9/1092042979.geojson
+++ b/data/109/204/297/9/1092042979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.32078,
-    "geom:area_square_m":27900772902.249687,
+    "geom:area_square_m":27900772786.151093,
     "geom:bbox":"116.848663,46.353984,119.931949,48.048079",
     "geom:latitude":47.195974,
     "geom:longitude":118.19928,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.DD.HA",
         "wd:id":"Q384528"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898242,
-    "wof:geomhash":"197225b215ababb45c385343089041a9",
+    "wof:geomhash":"556740046c95f4eb378eb08aea81dc38",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092042979,
-    "wof:lastmodified":1690939721,
+    "wof:lastmodified":1695886845,
     "wof:name":"Xalx gol",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/204/302/7/1092043027.geojson
+++ b/data/109/204/302/7/1092043027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.444781,
-    "geom:area_square_m":3801266448.514312,
+    "geom:area_square_m":3801266358.685515,
     "geom:bbox":"112.441819,45.96895,113.471785,46.635123",
     "geom:latitude":46.27751,
     "geom:longitude":113.000588,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.SB.HA",
         "wd:id":"Q3396596"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898243,
-    "wof:geomhash":"035bb9193510ea7c574e42cb75f0e2ac",
+    "wof:geomhash":"cf074116e47f58a0d0da3a1efec198f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092043027,
-    "wof:lastmodified":1690939714,
+    "wof:lastmodified":1695886030,
     "wof:name":"Xalzan",
     "wof:parent_id":85674793,
     "wof:placetype":"county",

--- a/data/109/204/307/3/1092043073.geojson
+++ b/data/109/204/307/3/1092043073.geojson
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1092043073,
-    "wof:lastmodified":1694492705,
+    "wof:lastmodified":1695886030,
     "wof:name":"Xan-Uul",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/204/307/3/1092043073.geojson
+++ b/data/109/204/307/3/1092043073.geojson
@@ -64,6 +64,7 @@
     "wof:concordances":{
         "hasc:id":"MN.UB.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898245,
     "wof:geomhash":"9703d8530782b8f2bdbf7a8e3f9e057d",
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092043073,
-    "wof:lastmodified":1695886030,
+    "wof:lastmodified":1696023153,
     "wof:name":"Xan-Uul",
     "wof:parent_id":85674783,
     "wof:placetype":"county",

--- a/data/109/204/310/5/1092043105.geojson
+++ b/data/109/204/310/5/1092043105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.649485,
-    "geom:area_square_m":14933180994.303596,
+    "geom:area_square_m":14933181359.129639,
     "geom:bbox":"106.444889,42.259254,108.089203,43.5329",
     "geom:latitude":42.931661,
     "geom:longitude":107.300141,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.OG.HB",
         "wd:id":"Q3402208"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898246,
-    "wof:geomhash":"551fb05247d86859da8319d549a94624",
+    "wof:geomhash":"45d007123c6d12209b6f689308f6fc0a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092043105,
-    "wof:lastmodified":1690939724,
+    "wof:lastmodified":1695886020,
     "wof:name":"Xanbogd",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/204/315/3/1092043153.geojson
+++ b/data/109/204/315/3/1092043153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.466012,
-    "geom:area_square_m":3873169533.380247,
+    "geom:area_square_m":3873169127.510984,
     "geom:bbox":"98.760482,47.46068,100.090259,48.049581",
     "geom:latitude":47.766423,
     "geom:longitude":99.377958,
@@ -131,9 +131,10 @@
         "hasc:id":"MN.AR.HG",
         "wd:id":"Q2593940"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898248,
-    "wof:geomhash":"c8ee5fd4be85b758c32783112e0a3dd0",
+    "wof:geomhash":"8935dd45b644d21c8fda87ab694cbd32",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1092043153,
-    "wof:lastmodified":1690939710,
+    "wof:lastmodified":1695886844,
     "wof:name":"Xangai",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/204/320/1/1092043201.geojson
+++ b/data/109/204/320/1/1092043201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198589,
-    "geom:area_square_m":1599372114.441288,
+    "geom:area_square_m":1599372217.691914,
     "geom:bbox":"104.0651,49.079693,104.697106,49.668876",
     "geom:latitude":49.358746,
     "geom:longitude":104.397231,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BU.HL",
         "wd:id":"Q2993306"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898249,
-    "wof:geomhash":"2f24ebdf9fd90bbc841429bd37915cdc",
+    "wof:geomhash":"f0c8f46664383d24ab0c47ff5363ab97",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092043201,
-    "wof:lastmodified":1690939723,
+    "wof:lastmodified":1695886030,
     "wof:name":"Xangal",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/204/323/9/1092043239.geojson
+++ b/data/109/204/323/9/1092043239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.15411,
-    "geom:area_square_m":10327260665.832394,
+    "geom:area_square_m":10327260938.324472,
     "geom:bbox":"103.839381,43.114291,105.389724,44.273099",
     "geom:latitude":43.641499,
     "geom:longitude":104.635502,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.OG.HH",
         "wd:id":"Q3402358"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898251,
-    "wof:geomhash":"8a8bfcc81893e109c986c13eff312097",
+    "wof:geomhash":"f53a029c1b09e510ccaa295cd8cd436c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092043239,
-    "wof:lastmodified":1690939710,
+    "wof:lastmodified":1695886030,
     "wof:name":"Xanxongor",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/204/328/1/1092043281.geojson
+++ b/data/109/204/328/1/1092043281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.807429,
-    "geom:area_square_m":6249446595.761477,
+    "geom:area_square_m":6249447091.997242,
     "geom:bbox":"100.038567,50.4529,101.214144,51.750232",
     "geom:latitude":51.247835,
     "geom:longitude":100.597792,
@@ -131,9 +131,10 @@
         "hasc:id":"MN.HG.HA",
         "wd:id":"Q2607700"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898252,
-    "wof:geomhash":"953e54bfa280ece4b63f794917522bd0",
+    "wof:geomhash":"595ff3744d38189a2b30244867625eab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1092043281,
-    "wof:lastmodified":1690939724,
+    "wof:lastmodified":1695886845,
     "wof:name":"Xanx",
     "wof:parent_id":85674741,
     "wof:placetype":"county",

--- a/data/109/204/332/7/1092043327.geojson
+++ b/data/109/204/332/7/1092043327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.272169,
-    "geom:area_square_m":2289665806.330057,
+    "geom:area_square_m":2289666077.392655,
     "geom:bbox":"102.537708,46.884987,103.507075,47.426653",
     "geom:latitude":47.12891,
     "geom:longitude":102.999481,
@@ -143,9 +143,10 @@
         "hasc:id":"MN.OH.HR",
         "wd:id":"Q932069"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898254,
-    "wof:geomhash":"618401d2ae2ba9116b0496f3c395fd96",
+    "wof:geomhash":"8d720f130122e57d52cc60ce3df74db2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1092043327,
-    "wof:lastmodified":1690939712,
+    "wof:lastmodified":1695886844,
     "wof:name":"Xarxorin",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/204/337/3/1092043373.geojson
+++ b/data/109/204/337/3/1092043373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.310225,
-    "geom:area_square_m":2594680162.353004,
+    "geom:area_square_m":2594680256.253467,
     "geom:bbox":"102.678082,47.189909,103.683385,47.764178",
     "geom:latitude":47.43662,
     "geom:longitude":103.168314,
@@ -116,9 +116,10 @@
         "hasc:id":"MN.AR.HS",
         "wd:id":"Q2093510"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898255,
-    "wof:geomhash":"0a0a585954fccb7b7c2bd3277ce14d44",
+    "wof:geomhash":"d65a014477358e9989815572f12585fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1092043373,
-    "wof:lastmodified":1690939701,
+    "wof:lastmodified":1695886030,
     "wof:name":"Xashaat",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/204/340/5/1092043405.geojson
+++ b/data/109/204/340/5/1092043405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.057885,
-    "geom:area_square_m":18619623059.389172,
+    "geom:area_square_m":18619623304.296589,
     "geom:bbox":"107.988036,42.396397,110.464382,43.651885",
     "geom:latitude":42.967834,
     "geom:longitude":109.007985,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DG.HA",
         "wd:id":"Q3410020"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898257,
-    "wof:geomhash":"23ca3fe1ebe20eea55aca22caaec281e",
+    "wof:geomhash":"58e3ed39d908a6fb4e76452583fe8a46",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092043405,
-    "wof:lastmodified":1690939711,
+    "wof:lastmodified":1695886030,
     "wof:name":"Xatanbulag",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/204/344/7/1092043447.geojson
+++ b/data/109/204/344/7/1092043447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.451218,
-    "geom:area_square_m":3759596404.256207,
+    "geom:area_square_m":3759596316.583942,
     "geom:bbox":"109.737221,47.27406,111.072048,47.993954",
     "geom:latitude":47.636014,
     "geom:longitude":110.531305,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HN.HE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898258,
-    "wof:geomhash":"af22b58b505f0ec9e6349663550c41c6",
+    "wof:geomhash":"4c21080917fb3735bde0292f9e60bc12",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092043447,
-    "wof:lastmodified":1627522379,
+    "wof:lastmodified":1695886030,
     "wof:name":"Xerlen",
     "wof:parent_id":85674719,
     "wof:placetype":"county",

--- a/data/109/204/348/7/1092043487.geojson
+++ b/data/109/204/348/7/1092043487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.295893,
-    "geom:area_square_m":2438499718.675908,
+    "geom:area_square_m":2438499519.378287,
     "geom:bbox":"103.134375,47.841547,103.997302,48.576547",
     "geom:latitude":48.203869,
     "geom:longitude":103.509652,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BU.HO",
         "wd:id":"Q2606152"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898260,
-    "wof:geomhash":"9ac218c429db688ae994e1958df6a9e6",
+    "wof:geomhash":"b1d8b522e9f7d6cae56dde67aa86c4c7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092043487,
-    "wof:lastmodified":1690939709,
+    "wof:lastmodified":1695886030,
     "wof:name":"Xishig-O'ndor",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/204/351/7/1092043517.geojson
+++ b/data/109/204/351/7/1092043517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.457584,
-    "geom:area_square_m":3795377365.009418,
+    "geom:area_square_m":3795377208.979345,
     "geom:bbox":"112.500223,47.533875,113.695332,48.320138",
     "geom:latitude":47.872067,
     "geom:longitude":113.039229,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.DD.HO",
         "wd:id":"Q3404242"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898261,
-    "wof:geomhash":"f6c6b9d7f81fa39e7c95b2447dc87bf1",
+    "wof:geomhash":"3fea0f98c0066b6f9368fd045a7467a8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092043517,
-    "wof:lastmodified":1690939713,
+    "wof:lastmodified":1695886030,
     "wof:name":"Xo'lonbuir",
     "wof:parent_id":85674787,
     "wof:placetype":"county",

--- a/data/109/204/355/5/1092043555.geojson
+++ b/data/109/204/355/5/1092043555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.938139,
-    "geom:area_square_m":8421921466.141516,
+    "geom:area_square_m":8421920974.277326,
     "geom:bbox":"108.848846,42.833215,110.958146,44.013686",
     "geom:latitude":43.446363,
     "geom:longitude":109.901235,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.DG.HO",
         "wd:id":"Q3410111"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898262,
-    "wof:geomhash":"4fa8ef87a4537ede77df50e088c546a1",
+    "wof:geomhash":"9abfde4f094d668f509b7b7f25394d9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092043555,
-    "wof:lastmodified":1690939702,
+    "wof:lastmodified":1695886843,
     "wof:name":"Xo'vsgol",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/204/360/1/1092043601.geojson
+++ b/data/109/204/360/1/1092043601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.750904,
-    "geom:area_square_m":6281445201.216448,
+    "geom:area_square_m":6281444729.498436,
     "geom:bbox":"93.513113,46.989935,95.185257,47.791517",
     "geom:latitude":47.428243,
     "geom:longitude":94.374216,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.GA.HO",
         "wd:id":"Q3404372"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898264,
-    "wof:geomhash":"9afb3ebba6262a450cb58b91ab4188ac",
+    "wof:geomhash":"aafd42e171e75e6b2a64fd30ce25d842",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092043601,
-    "wof:lastmodified":1690939714,
+    "wof:lastmodified":1695886031,
     "wof:name":"Xo'xmorit",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/204/364/5/1092043645.geojson
+++ b/data/109/204/364/5/1092043645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.325793,
-    "geom:area_square_m":2623136245.68323,
+    "geom:area_square_m":2623136359.173757,
     "geom:bbox":"105.85158,49.124066,106.81992,49.650133",
     "geom:latitude":49.371924,
     "geom:longitude":106.330322,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.DA.HO",
         "wd:id":"Q3874412"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898265,
-    "wof:geomhash":"c1a6b34ba26073db50d8353ac6d9c9c9",
+    "wof:geomhash":"dc2ee2cb340eb9020d7a6e362d0984e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092043645,
-    "wof:lastmodified":1690939702,
+    "wof:lastmodified":1695886031,
     "wof:name":"Xongor",
     "wof:parent_id":85674769,
     "wof:placetype":"county",

--- a/data/109/204/369/1/1092043691.geojson
+++ b/data/109/204/369/1/1092043691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.278773,
-    "geom:area_square_m":2339410059.528104,
+    "geom:area_square_m":2339410013.880127,
     "geom:bbox":"102.02832,46.911409,102.74745,47.581609",
     "geom:latitude":47.260561,
     "geom:longitude":102.39691,
@@ -128,9 +128,10 @@
         "hasc:id":"MN.AR.HO",
         "wd:id":"Q2089849"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898267,
-    "wof:geomhash":"733bea0d9b632a7203e5449338518485",
+    "wof:geomhash":"3772b5a45ecf7b8372986b89bba328f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092043691,
-    "wof:lastmodified":1690939713,
+    "wof:lastmodified":1695886844,
     "wof:name":"Xotont",
     "wof:parent_id":85674721,
     "wof:placetype":"county",

--- a/data/109/204/371/7/1092043717.geojson
+++ b/data/109/204/371/7/1092043717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.355918,
-    "geom:area_square_m":2863678922.140565,
+    "geom:area_square_m":2863677918.309663,
     "geom:bbox":"90.608457,49.031666,91.458916,49.699427",
     "geom:latitude":49.406312,
     "geom:longitude":91.056667,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.UV.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898269,
-    "wof:geomhash":"02aa4e5bdec700b6a433c2494619884c",
+    "wof:geomhash":"37d8214180d4c76865606e4c0aeb303a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092043717,
-    "wof:lastmodified":1627522380,
+    "wof:lastmodified":1695886031,
     "wof:name":"Xovd",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/204/376/9/1092043769.geojson
+++ b/data/109/204/376/9/1092043769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.343795,
-    "geom:area_square_m":2839123141.441184,
+    "geom:area_square_m":2839123366.84573,
     "geom:bbox":"90.806381,47.703052,91.904834,48.361309",
     "geom:latitude":48.097927,
     "geom:longitude":91.316079,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.HD.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898276,
-    "wof:geomhash":"c1b039f1e89e0e7ff9e11c3adfe8537e",
+    "wof:geomhash":"979fa3e6389506d9d77850fbe6db157f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092043769,
-    "wof:lastmodified":1627522380,
+    "wof:lastmodified":1695886031,
     "wof:name":"Xovd",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/204/381/7/1092043817.geojson
+++ b/data/109/204/381/7/1092043817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.333366,
-    "geom:area_square_m":2664298778.685184,
+    "geom:area_square_m":2664298614.546053,
     "geom:bbox":"107.149017,49.466413,108.038703,50.004412",
     "geom:latitude":49.733642,
     "geom:longitude":107.595121,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.SL.HD",
         "wd:id":"Q2748160"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898277,
-    "wof:geomhash":"32370e88a784d346fecf5ee2103d3384",
+    "wof:geomhash":"21ff69f8f98d592655e196b866206021",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092043817,
-    "wof:lastmodified":1690939724,
+    "wof:lastmodified":1695886845,
     "wof:name":"Xu'der",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/386/5/1092043865.geojson
+++ b/data/109/204/386/5/1092043865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.509232,
-    "geom:area_square_m":4336095335.828768,
+    "geom:area_square_m":4336095047.475821,
     "geom:bbox":"97.667084,46.014214,98.932493,46.93826",
     "geom:latitude":46.478508,
     "geom:longitude":98.322233,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BH.HU",
         "wd:id":"Q2093450"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898279,
-    "wof:geomhash":"1534f471a4876a678fae2dc20510e49f",
+    "wof:geomhash":"d8c073e380785797603cd356e2be8e79",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092043865,
-    "wof:lastmodified":1690939725,
+    "wof:lastmodified":1695886031,
     "wof:name":"Xu'reemaral",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/204/390/9/1092043909.geojson
+++ b/data/109/204/390/9/1092043909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.386823,
-    "geom:area_square_m":12637005203.731953,
+    "geom:area_square_m":12637005546.243517,
     "geom:bbox":"103.008761,41.799409,104.395769,43.484421",
     "geom:latitude":42.528161,
     "geom:longitude":103.830295,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.OG.HU",
         "wd:id":"Q3403822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898280,
-    "wof:geomhash":"28571aaf56f6787cd34b9c17da6096ec",
+    "wof:geomhash":"17f1c48776f897007b580667493eae83",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092043909,
-    "wof:lastmodified":1690939703,
+    "wof:lastmodified":1695886031,
     "wof:name":"Xu'rmen",
     "wof:parent_id":85674713,
     "wof:placetype":"county",

--- a/data/109/204/393/9/1092043939.geojson
+++ b/data/109/204/393/9/1092043939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.200083,
-    "geom:area_square_m":1691766456.200923,
+    "geom:area_square_m":1691766043.118435,
     "geom:bbox":"102.371021,46.698002,103.358257,47.11213",
     "geom:latitude":46.858739,
     "geom:longitude":102.803831,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.OH.HU",
         "wd:id":"Q3396568"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898281,
-    "wof:geomhash":"9046d7f7c0a240158757d7612382ef64",
+    "wof:geomhash":"e18f0ad97d1c312a7e91da250ef165d6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092043939,
-    "wof:lastmodified":1690939714,
+    "wof:lastmodified":1695886031,
     "wof:name":"Xujirt",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/204/398/7/1092043987.geojson
+++ b/data/109/204/398/7/1092043987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.695327,
-    "geom:area_square_m":6067731627.099205,
+    "geom:area_square_m":6067732073.571606,
     "geom:bbox":"105.016905,44.688409,106.135957,45.670092",
     "geom:latitude":45.111251,
     "geom:longitude":105.502068,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.DU.HU",
         "wd:id":"Q3404270"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898283,
-    "wof:geomhash":"12662cb2e7d03cc6c64ea9be9acbed63",
+    "wof:geomhash":"bd6b2988da8c6ec378c790b56ae17012",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092043987,
-    "wof:lastmodified":1690939701,
+    "wof:lastmodified":1695886031,
     "wof:name":"Xuld",
     "wof:parent_id":85674757,
     "wof:placetype":"county",

--- a/data/109/204/403/3/1092044033.geojson
+++ b/data/109/204/403/3/1092044033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.250374,
-    "geom:area_square_m":2001680439.147557,
+    "geom:area_square_m":2001680344.820402,
     "geom:bbox":"104.894139,49.461358,105.896159,49.976528",
     "geom:latitude":49.717615,
     "geom:longitude":105.45162,
@@ -101,9 +101,10 @@
         "hasc:id":"MN.SL.HZ",
         "wd:id":"Q2748155"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898284,
-    "wof:geomhash":"ca5ca1c117dce9054a3122d367ea2362",
+    "wof:geomhash":"eb60811e1e9de80244f4856f9256360e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092044033,
-    "wof:lastmodified":1690939722,
+    "wof:lastmodified":1695886845,
     "wof:name":"Xushaat",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/407/1/1092044071.geojson
+++ b/data/109/204/407/1/1092044071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.696296,
-    "geom:area_square_m":5604505870.04579,
+    "geom:area_square_m":5604506376.066278,
     "geom:bbox":"102.210687,48.834766,103.73721,49.746106",
     "geom:latitude":49.387029,
     "geom:longitude":102.929477,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.BU.HU",
         "wd:id":"Q2606158"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898286,
-    "wof:geomhash":"26965f3f624dce7e126258feab3f7859",
+    "wof:geomhash":"a6bd1c090af09d0675ffde39995089a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092044071,
-    "wof:lastmodified":1690939708,
+    "wof:lastmodified":1695886031,
     "wof:name":"Xutag-O'ndor",
     "wof:parent_id":85674749,
     "wof:placetype":"county",

--- a/data/109/204/411/7/1092044117.geojson
+++ b/data/109/204/411/7/1092044117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.401182,
-    "geom:area_square_m":3219084716.817281,
+    "geom:area_square_m":3219084705.57299,
     "geom:bbox":"93.385922,49.180076,94.315949,49.846143",
     "geom:latitude":49.539669,
     "geom:longitude":93.844034,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.UV.HY",
         "wd:id":"Q3402411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898287,
-    "wof:geomhash":"8a591791c2babcd1f8cd78addb8ae9d3",
+    "wof:geomhash":"11c15fdea62a5d8309877dcb30ef16e1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092044117,
-    "wof:lastmodified":1690939717,
+    "wof:lastmodified":1695886032,
     "wof:name":"Xyargas",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/204/416/5/1092044165.geojson
+++ b/data/109/204/416/5/1092044165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.60028,
-    "geom:area_square_m":4954811862.679879,
+    "geom:area_square_m":4954813165.266928,
     "geom:bbox":"95.344462,47.698781,97.131648,48.604389",
     "geom:latitude":48.122709,
     "geom:longitude":96.437196,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.DZ.YA",
         "wd:id":"Q3403779"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898289,
-    "wof:geomhash":"cafd3f7357926cc62871337d293d2cf0",
+    "wof:geomhash":"35494441c01db4bdf833f10ee8db4bf8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092044165,
-    "wof:lastmodified":1690939717,
+    "wof:lastmodified":1695886032,
     "wof:name":"Yaruu",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/421/5/1092044215.geojson
+++ b/data/109/204/421/5/1092044215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.028413,
-    "geom:area_square_m":8277278715.385755,
+    "geom:area_square_m":8277279012.402043,
     "geom:bbox":"106.468804,49.007349,108.574916,49.984832",
     "geom:latitude":49.389605,
     "geom:longitude":107.441389,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.SL.YE",
         "wd:id":"Q2748133"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898290,
-    "wof:geomhash":"dea2e3a2e817dd32b671af9d73b1040b",
+    "wof:geomhash":"66adb419ab5b1d017973342ad797038f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092044215,
-    "wof:lastmodified":1690939715,
+    "wof:lastmodified":1695886844,
     "wof:name":"Yero'o",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/425/3/1092044253.geojson
+++ b/data/109/204/425/3/1092044253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.272678,
-    "geom:area_square_m":2332673991.210783,
+    "geom:area_square_m":2332673629.089063,
     "geom:bbox":"95.746352,45.940526,97.093918,46.474639",
     "geom:latitude":46.22431,
     "geom:longitude":96.327793,
@@ -83,9 +83,10 @@
         "hasc:id":"MN.GA.ES",
         "wd:id":"Q3404234"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898292,
-    "wof:geomhash":"e611d94d78b0eb918002e4335a7c3127",
+    "wof:geomhash":"1ac3aabf4d4f63d1567d6f05d8d49210",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1092044253,
-    "wof:lastmodified":1690939704,
+    "wof:lastmodified":1695886032,
     "wof:name":"Yeso'nbulag",
     "wof:parent_id":85674731,
     "wof:placetype":"county",

--- a/data/109/204/429/7/1092044297.geojson
+++ b/data/109/204/429/7/1092044297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.260914,
-    "geom:area_square_m":2216331925.26554,
+    "geom:area_square_m":2216331972.106756,
     "geom:bbox":"103.257215,46.2415,104.100267,46.993711",
     "geom:latitude":46.608999,
     "geom:longitude":103.709834,
@@ -122,9 +122,10 @@
         "hasc:id":"MN.OH.EZ",
         "wd:id":"Q3403943"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898293,
-    "wof:geomhash":"eeced9e52a8671b6b7202f634747cb0c",
+    "wof:geomhash":"b97bf4350001ec6b265b902b91d1010e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092044297,
-    "wof:lastmodified":1690939717,
+    "wof:lastmodified":1695886032,
     "wof:name":"Yeso'nzu'il",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/204/434/3/1092044343.geojson
+++ b/data/109/204/434/3/1092044343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.341961,
-    "geom:area_square_m":2815180834.800453,
+    "geom:area_square_m":2815180529.278987,
     "geom:bbox":"104.28525,47.913077,105.094297,48.643212",
     "geom:latitude":48.257844,
     "geom:longitude":104.699739,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.TO.ZA",
         "wd:id":"Q3396630"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898294,
-    "wof:geomhash":"f4e5c8ebb8c9a4990837c25f81019ec4",
+    "wof:geomhash":"62122b114411a3717f235e3a5348b0dc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092044343,
-    "wof:lastmodified":1690939721,
+    "wof:lastmodified":1695886032,
     "wof:name":"Zaamar",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/204/438/1/1092044381.geojson
+++ b/data/109/204/438/1/1092044381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.299924,
-    "geom:area_square_m":2534210316.612985,
+    "geom:area_square_m":2534210312.025124,
     "geom:bbox":"98.814338,46.581012,99.558223,47.269199",
     "geom:latitude":46.895408,
     "geom:longitude":99.158491,
@@ -110,9 +110,10 @@
         "hasc:id":"MN.BH.ZA",
         "wd:id":"Q2093530"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898296,
-    "wof:geomhash":"782e7b93b70f82beebad606b39b7d29c",
+    "wof:geomhash":"8432f1251ad196eeccdfe698f50cd204",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1092044381,
-    "wof:lastmodified":1690939709,
+    "wof:lastmodified":1695886032,
     "wof:name":"Zag",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/109/204/442/7/1092044427.geojson
+++ b/data/109/204/442/7/1092044427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054101,
-    "geom:area_square_m":482835871.001129,
+    "geom:area_square_m":482835932.833307,
     "geom:bbox":"111.669898,43.66637,111.964374,43.949872",
     "geom:latitude":43.80032,
     "geom:longitude":111.83131,
@@ -152,9 +152,10 @@
         "hasc:id":"MN.DG.ZA",
         "wd:id":"Q2084833"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898297,
-    "wof:geomhash":"9d0435f52e539d0387644c3691a319f6",
+    "wof:geomhash":"9807cb7799383b0811bfd2e7a2e4e7bb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":1092044427,
-    "wof:lastmodified":1690939718,
+    "wof:lastmodified":1695886844,
     "wof:name":"Zamyn U'ud",
     "wof:parent_id":85674709,
     "wof:placetype":"county",

--- a/data/109/204/446/9/1092044469.geojson
+++ b/data/109/204/446/9/1092044469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.435468,
-    "geom:area_square_m":3592109899.743741,
+    "geom:area_square_m":3592109809.311275,
     "geom:bbox":"94.38751,47.847293,95.575806,48.428691",
     "geom:latitude":48.156051,
     "geom:longitude":94.897963,
@@ -107,9 +107,10 @@
         "hasc:id":"MN.DZ.ZA",
         "wd:id":"Q3403766"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898299,
-    "wof:geomhash":"68695803af7ab41d0fb623b5629520e7",
+    "wof:geomhash":"cfcd4a07a1fc0b19ede987db62e0f26f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092044469,
-    "wof:lastmodified":1690939705,
+    "wof:lastmodified":1695886032,
     "wof:name":"Zavxanmandal",
     "wof:parent_id":85674727,
     "wof:placetype":"county",

--- a/data/109/204/451/5/1092044515.geojson
+++ b/data/109/204/451/5/1092044515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.8466,
-    "geom:area_square_m":6880698461.807062,
+    "geom:area_square_m":6880698787.312225,
     "geom:bbox":"92.536319,48.419928,94.061722,49.34029",
     "geom:latitude":48.906605,
     "geom:longitude":93.205979,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.UV.ZV",
         "wd:id":"Q3402369"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898300,
-    "wof:geomhash":"57a8d481e29b1c061c2fd97959634f41",
+    "wof:geomhash":"ff2f013174731ede49d5e1aadddd83f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092044515,
-    "wof:lastmodified":1690939720,
+    "wof:lastmodified":1695886032,
     "wof:name":"Zavxan",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/204/455/1/1092044551.geojson
+++ b/data/109/204/455/1/1092044551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298891,
-    "geom:area_square_m":2514477864.120055,
+    "geom:area_square_m":2514478081.712521,
     "geom:bbox":"92.412479,46.820964,93.221646,47.447324",
     "geom:latitude":47.128639,
     "geom:longitude":92.851551,
@@ -125,9 +125,10 @@
         "hasc:id":"MN.HD.ZE",
         "wd:id":"Q3404073"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898302,
-    "wof:geomhash":"25ed1504226f68547ad22bf30e69ffa1",
+    "wof:geomhash":"1ef687a4646eb45340c80bac80b4afc4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1092044551,
-    "wof:lastmodified":1690939707,
+    "wof:lastmodified":1695886844,
     "wof:name":"Zereg",
     "wof:parent_id":85674737,
     "wof:placetype":"county",

--- a/data/109/204/458/9/1092044589.geojson
+++ b/data/109/204/458/9/1092044589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.294112,
-    "geom:area_square_m":2503079954.233864,
+    "geom:area_square_m":2503080130.488994,
     "geom:bbox":"102.347797,46.097541,103.309053,46.754452",
     "geom:latitude":46.506255,
     "geom:longitude":102.863769,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.OH.ZU",
         "wd:id":"Q3403860"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898303,
-    "wof:geomhash":"dac64af3e563046663cefb676a5f9dbe",
+    "wof:geomhash":"0978b379f0e6e8c759c4aee7b5c1e2d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092044589,
-    "wof:lastmodified":1690939719,
+    "wof:lastmodified":1695886032,
     "wof:name":"Zu'unbayan-Ulaan",
     "wof:parent_id":85674765,
     "wof:placetype":"county",

--- a/data/109/204/463/5/1092044635.geojson
+++ b/data/109/204/463/5/1092044635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149438,
-    "geom:area_square_m":1188754301.201308,
+    "geom:area_square_m":1188754306.735384,
     "geom:bbox":"105.617297,49.693348,106.194456,50.251086",
     "geom:latitude":49.959809,
     "geom:longitude":105.931333,
@@ -98,9 +98,10 @@
         "hasc:id":"MN.SL.ZU",
         "wd:id":"Q2748000"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898304,
-    "wof:geomhash":"e3598e28fe04bf137b899bc5f66e0400",
+    "wof:geomhash":"ac34e799ec08b6334b249d6ad5cb3b1a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092044635,
-    "wof:lastmodified":1690939707,
+    "wof:lastmodified":1695886844,
     "wof:name":"Zu'unburen",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/467/7/1092044677.geojson
+++ b/data/109/204/467/7/1092044677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.504591,
-    "geom:area_square_m":4003923342.40625,
+    "geom:area_square_m":4003923405.78399,
     "geom:bbox":"93.326871,49.820647,94.611499,50.415713",
     "geom:latitude":50.079709,
     "geom:longitude":93.991243,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.UV.ZG",
         "wd:id":"Q3403984"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898306,
-    "wof:geomhash":"cb99c78dfc7bb0f55e82c0ce97264a0d",
+    "wof:geomhash":"7b14e44d0d7127492c52e6b51e822cb0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092044677,
-    "wof:lastmodified":1690939719,
+    "wof:lastmodified":1695886033,
     "wof:name":"Zu'ungovi",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/204/471/7/1092044717.geojson
+++ b/data/109/204/471/7/1092044717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.327307,
-    "geom:area_square_m":2641182779.04593,
+    "geom:area_square_m":2641182555.603958,
     "geom:bbox":"95.026042,48.772263,95.686895,49.751052",
     "geom:latitude":49.262255,
     "geom:longitude":95.353404,
@@ -104,9 +104,10 @@
         "hasc:id":"MN.UV.ZH",
         "wd:id":"Q3396467"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898308,
-    "wof:geomhash":"e1ebe421f9e89e03518e003e9f0ce24e",
+    "wof:geomhash":"a86983369ed8a08cf2013fbad1134280",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092044717,
-    "wof:lastmodified":1690939703,
+    "wof:lastmodified":1695886033,
     "wof:name":"Zu'unxangai",
     "wof:parent_id":85674745,
     "wof:placetype":"county",

--- a/data/109/204/475/7/1092044757.geojson
+++ b/data/109/204/475/7/1092044757.geojson
@@ -94,6 +94,7 @@
         "hasc:id":"MN.SL.MA",
         "wd:id":"Q2748006"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898309,
     "wof:geomhash":"d889720f6829710295de242b4ddcf710",
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1092044757,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886844,
     "wof:name":"Zu'unxaraa",
     "wof:parent_id":85674761,
     "wof:placetype":"county",

--- a/data/109/204/480/1/1092044801.geojson
+++ b/data/109/204/480/1/1092044801.geojson
@@ -85,6 +85,7 @@
         "hasc:id":"MN.TO.SE",
         "wd:id":"Q3396295"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898310,
     "wof:geomhash":"419fe911f2e3acbf1baca16d7fa8e09b",
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092044801,
-    "wof:lastmodified":1694498060,
+    "wof:lastmodified":1695886033,
     "wof:name":"Zuunmod",
     "wof:parent_id":85674777,
     "wof:placetype":"county",

--- a/data/109/204/482/9/1092044829.geojson
+++ b/data/109/204/482/9/1092044829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.45807,
-    "geom:area_square_m":3936585749.890904,
+    "geom:area_square_m":3936585356.280452,
     "geom:bbox":"100.428673,45.571795,101.504348,46.366265",
     "geom:latitude":45.972225,
     "geom:longitude":101.002161,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"MN.BH.OL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MN",
     "wof:created":1473898312,
-    "wof:geomhash":"96414ac14071b003447d9c86ddb7b4fe",
+    "wof:geomhash":"f35d5388ed5e2fff2c0e5e3e90be3c7d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1092044829,
-    "wof:lastmodified":1627522373,
+    "wof:lastmodified":1695886022,
     "wof:name":"O'lziit",
     "wof:parent_id":85674723,
     "wof:placetype":"county",

--- a/data/856/324/39/85632439.geojson
+++ b/data/856/324/39/85632439.geojson
@@ -1204,6 +1204,7 @@
         "hasc:id":"MN",
         "icao:code":"JU",
         "ioc:id":"MGL",
+        "iso:code":"MN",
         "itu:id":"MNG",
         "m49:code":"496",
         "marc:id":"mp",
@@ -1217,6 +1218,7 @@
         "wk:page":"Mongolia",
         "wmo:id":"MO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:country_alpha3":"MNG",
     "wof:geom_alt":[
@@ -1238,7 +1240,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1694639562,
+    "wof:lastmodified":1695881220,
     "wof:name":"Mongolia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/747/05/85674705.geojson
+++ b/data/856/747/05/85674705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.575631,
-    "geom:area_square_m":45640244057.204483,
+    "geom:area_square_m":45640244515.213341,
     "geom:bbox":"87.73762,46.550602,91.921412,50.001541",
     "geom:latitude":48.543623,
     "geom:longitude":89.850613,
@@ -345,17 +345,19 @@
         "gn:id":1516278,
         "gp:id":2346159,
         "hasc:id":"MN.BO",
+        "iso:code":"MN-071",
         "iso:id":"MN-071",
         "qs_pg:id":211643,
         "unlc:id":"MN-071",
         "wd:id":"Q191792",
         "wk:page":"Bayan-\u00d6lgii Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4a7295627104fdfb85638169e99ae549",
+    "wof:geomhash":"f6c3bbcbad8cfbe6e5f93733bb367f5e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -370,7 +372,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939693,
+    "wof:lastmodified":1695884375,
     "wof:name":"Bayan-\u00d6lgiy",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/09/85674709.geojson
+++ b/data/856/747/09/85674709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.367224,
-    "geom:area_square_m":109186763963.771332,
+    "geom:area_square_m":109186762816.015015,
     "geom:bbox":"107.654808,42.396397,111.986236,46.633321",
     "geom:latitude":44.42959,
     "geom:longitude":109.805523,
@@ -338,17 +338,19 @@
         "gn:id":2031798,
         "gp:id":2346161,
         "hasc:id":"MN.DG",
+        "iso:code":"MN-063",
         "iso:id":"MN-063",
         "qs_pg:id":211645,
         "unlc:id":"MN-063",
         "wd:id":"Q213272",
         "wk:page":"Dornogovi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"44fbbc3493206b7bd1fdf960d96e6760",
+    "wof:geomhash":"8beb1752e635916cfd3cea8e82811356",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -363,7 +365,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939696,
+    "wof:lastmodified":1695884376,
     "wof:name":"Dornogovi",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/13/85674713.geojson
+++ b/data/856/747/13/85674713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":18.321519,
-    "geom:area_square_m":164902422410.173492,
+    "geom:area_square_m":164902422780.356995,
     "geom:bbox":"99.42928,41.58152,108.089203,45.173947",
     "geom:latitude":43.285594,
     "geom:longitude":104.122798,
@@ -338,16 +338,18 @@
         "gn:id":2029669,
         "gp:id":2346168,
         "hasc:id":"MN.OG",
+        "iso:code":"MN-053",
         "iso:id":"MN-053",
         "qs_pg:id":1252049,
         "unlc:id":"MN-053",
         "wd:id":"Q235579"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ca2d65d5b169d675bf34f7058d9c57f4",
+    "wof:geomhash":"09126ea447a5c6aebe8e3fbd0c8e59d1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -362,7 +364,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939700,
+    "wof:lastmodified":1695884377,
     "wof:name":"\u00d6mn\u00f6govi",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/19/85674719.geojson
+++ b/data/856/747/19/85674719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.712294,
-    "geom:area_square_m":80521443993.616135,
+    "geom:area_square_m":80521442708.289078,
     "geom:bbox":"108.404512,46.059307,112.723034,49.414212",
     "geom:latitude":47.890056,
     "geom:longitude":110.445603,
@@ -324,17 +324,19 @@
         "gn:id":2030783,
         "gp:id":2346165,
         "hasc:id":"MN.HN",
+        "iso:code":"MN-039",
         "iso:id":"MN-039",
         "qs_pg:id":423802,
         "unlc:id":"MN-039",
         "wd:id":"Q239040",
         "wk:page":"Khentii Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b6eada989fd245b88a463f6ddd744251",
+    "wof:geomhash":"c28f8b5667e864bde5bb6882659cb971",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -349,7 +351,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939695,
+    "wof:lastmodified":1695884376,
     "wof:name":"Hentiy",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/21/85674721.geojson
+++ b/data/856/747/21/85674721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.648964,
-    "geom:area_square_m":55140169530.214714,
+    "geom:area_square_m":55140169279.784363,
     "geom:bbox":"98.171942,46.766265,103.683385,49.222039",
     "geom:latitude":47.878556,
     "geom:longitude":101.026872,
@@ -336,17 +336,19 @@
         "gn:id":2032855,
         "gp:id":2346157,
         "hasc:id":"MN.AR",
+        "iso:code":"MN-073",
         "iso:id":"MN-073",
         "qs_pg:id":1083845,
         "unlc:id":"MN-073",
         "wd:id":"Q207809",
         "wk:page":"Arkhangai Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3087d74184665a4ddbe75ca1e2025f71",
+    "wof:geomhash":"4c58749bce83a3d22477330615d4fc38",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -361,7 +363,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939695,
+    "wof:lastmodified":1695884376,
     "wof:name":"Arhangay",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/23/85674723.geojson
+++ b/data/856/747/23/85674723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":13.257848,
-    "geom:area_square_m":115380247408.664383,
+    "geom:area_square_m":115380248091.998291,
     "geom:bbox":"97.632146,42.565788,101.742119,47.739982",
     "geom:latitude":45.251727,
     "geom:longitude":99.516912,
@@ -331,17 +331,19 @@
         "gn:id":1516290,
         "gp:id":2346158,
         "hasc:id":"MN.BH",
+        "iso:code":"MN-069",
         "iso:id":"MN-069",
         "qs_pg:id":1222560,
         "unlc:id":"MN-069",
         "wd:id":"Q276200",
         "wk:page":"Bayankhongor Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"51b4b8c28edb98636e70dd7e32e8146a",
+    "wof:geomhash":"4bc930adaf19d57608ca69b4d78c894a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -356,7 +358,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939699,
+    "wof:lastmodified":1695884377,
     "wof:name":"Bayanhongor",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/27/85674727.geojson
+++ b/data/856/747/27/85674727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.006662,
-    "geom:area_square_m":82309479306.189301,
+    "geom:area_square_m":82309479769.671021,
     "geom:bbox":"93.262098,46.565857,99.20779,50.043986",
     "geom:latitude":48.297391,
     "geom:longitude":96.445315,
@@ -330,17 +330,19 @@
         "gn:id":1516012,
         "gp:id":2346163,
         "hasc:id":"MN.DZ",
+        "iso:code":"MN-057",
         "iso:id":"MN-057",
         "qs_pg:id":219572,
         "unlc:id":"MN-057",
         "wd:id":"Q167764",
         "wk:page":"Zavkhan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5e8e44821ccdf0a1ee04383145cee2a5",
+    "wof:geomhash":"986bb85c275ec0d4caaedd12454dc902",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -355,7 +357,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939694,
+    "wof:lastmodified":1695884376,
     "wof:name":"Dzavxan",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/31/85674731.geojson
+++ b/data/856/747/31/85674731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":16.276683,
-    "geom:area_square_m":141429049417.770233,
+    "geom:area_square_m":141429048195.421722,
     "geom:bbox":"93.100193,42.701953,98.490249,47.791517",
     "geom:latitude":45.34389,
     "geom:longitude":95.94606,
@@ -336,17 +336,19 @@
         "gn:id":1515917,
         "gp:id":2346164,
         "hasc:id":"MN.GA",
+        "iso:code":"MN-065",
         "iso:id":"MN-065",
         "qs_pg:id":219573,
         "unlc:id":"MN-065",
         "wd:id":"Q192945",
         "wk:page":"Govi-Altai Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9ead344ae78bd08f78db3588823008ec",
+    "wof:geomhash":"4731b9d4e91940680b61788cacabeb3f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -361,7 +363,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939696,
+    "wof:lastmodified":1695884377,
     "wof:name":"Govi-Altay",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/37/85674737.geojson
+++ b/data/856/747/37/85674737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.98077,
-    "geom:area_square_m":75862104084.381058,
+    "geom:area_square_m":75862104798.581741,
     "geom:bbox":"90.654385,44.99941,94.30601,48.966417",
     "geom:latitude":46.901559,
     "geom:longitude":92.289261,
@@ -308,17 +308,19 @@
         "gn:id":1515696,
         "gp:id":2346166,
         "hasc:id":"MN.HD",
+        "iso:code":"MN-043",
         "iso:id":"MN-043",
         "qs_pg:id":219574,
         "unlc:id":"MN-043",
         "wd:id":"Q194098",
         "wk:page":"Khovd Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b80a60868f3b7937fbd8e37528f365e",
+    "wof:geomhash":"0dfa128399355819e4763052b60c04d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939697,
+    "wof:lastmodified":1695884957,
     "wof:name":"Hovd",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/41/85674741.geojson
+++ b/data/856/747/41/85674741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.732823,
-    "geom:area_square_m":100696054396.656036,
+    "geom:area_square_m":100696054363.555725,
     "geom:bbox":"96.838046,48.252978,102.752031,52.148696",
     "geom:latitude":50.235021,
     "geom:longitude":99.912188,
@@ -335,16 +335,18 @@
         "gn:id":2030469,
         "gp:id":2346167,
         "hasc:id":"MN.HG",
+        "iso:code":"MN-041",
         "iso:id":"MN-041",
         "qs_pg:id":423813,
         "wd:id":"Q244788",
         "wk:page":"Kh\u00f6vsg\u00f6l Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f80728e2d800ca97a5c72e0ecdfb81a",
+    "wof:geomhash":"59bc2af8ea52de13e5422cc2ed9c9599",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -359,7 +361,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939698,
+    "wof:lastmodified":1695884534,
     "wof:name":"H\u00f6vsg\u00f6l",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/45/85674745.geojson
+++ b/data/856/747/45/85674745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.662818,
-    "geom:area_square_m":69374164507.607712,
+    "geom:area_square_m":69374163501.300049,
     "geom:bbox":"89.999186,48.419928,95.686895,50.884476",
     "geom:latitude":49.633507,
     "geom:longitude":92.939983,
@@ -337,17 +337,19 @@
         "gn:id":1514967,
         "gp:id":2346173,
         "hasc:id":"MN.UV",
+        "iso:code":"MN-046",
         "iso:id":"MN-046",
         "qs_pg:id":1168590,
         "unlc:id":"MN-046",
         "wd:id":"Q192942",
         "wk:page":"Uvs Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0c9195dc93eb7bbbbaac0892b76602d",
+    "wof:geomhash":"e4c2d8d46ba4f4be79f71c24ae8e4474",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -362,7 +364,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939694,
+    "wof:lastmodified":1695884376,
     "wof:name":"Uvs",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/49/85674749.geojson
+++ b/data/856/747/49/85674749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.978294,
-    "geom:area_square_m":48529986119.162239,
+    "geom:area_square_m":48529985996.921898,
     "geom:bbox":"101.612056,47.236981,104.78046,50.439279",
     "geom:latitude":48.96233,
     "geom:longitude":103.397871,
@@ -334,17 +334,19 @@
         "gn:id":2032199,
         "gp:id":2346174,
         "hasc:id":"MN.BU",
+        "iso:code":"MN-067",
         "iso:id":"MN-067",
         "qs_pg:id":235579,
         "unlc:id":"MN-067",
         "wd:id":"Q209774",
         "wk:page":"Bulgan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"508d091315533ab2fa75b060ad4af917",
+    "wof:geomhash":"4926bf0dac24cfab04910383a7c3c761",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -359,7 +361,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939700,
+    "wof:lastmodified":1695884957,
     "wof:name":"Bulgan",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/51/85674751.geojson
+++ b/data/856/747/51/85674751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103195,
-    "geom:area_square_m":836394818.464542,
+    "geom:area_square_m":836395149.688684,
     "geom:bbox":"103.959526,48.902604,104.629473,49.170793",
     "geom:latitude":49.044604,
     "geom:longitude":104.296556,
@@ -340,16 +340,18 @@
         "gn:id":2055113,
         "gp:id":20070015,
         "hasc:id":"MN.ER",
+        "iso:code":"MN-035",
         "iso:id":"MN-035",
         "qs_pg:id":484685,
         "unlc:id":"MN-035",
         "wd:id":"Q234710"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01155c888955490572ac87e62f8c0ef6",
+    "wof:geomhash":"6d2ff895944cfbea054b92f8f0740c54",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -364,7 +366,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939692,
+    "wof:lastmodified":1695884956,
     "wof:name":"Orhon",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/57/85674757.geojson
+++ b/data/856/747/57/85674757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.602054,
-    "geom:area_square_m":74520150635.409897,
+    "geom:area_square_m":74520151161.475769,
     "geom:bbox":"103.608888,44.166209,108.67,46.779329",
     "geom:latitude":45.521877,
     "geom:longitude":106.273748,
@@ -331,17 +331,19 @@
         "gn:id":2031740,
         "gp:id":2346162,
         "hasc:id":"MN.DU",
+        "iso:code":"MN-059",
         "iso:id":"MN-059",
         "qs_pg:id":423801,
         "unlc:id":"MN-059",
         "wd:id":"Q211835",
         "wk:page":"Dundgovi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8342d14bd671c1379e6e2e827ff24467",
+    "wof:geomhash":"c7755ab36f921abfd6da51dcde52c343",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -356,7 +358,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939692,
+    "wof:lastmodified":1695884375,
     "wof:name":"Dundgovi",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/61/85674761.geojson
+++ b/data/856/747/61/85674761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.148203,
-    "geom:area_square_m":41361753705.814621,
+    "geom:area_square_m":41361753705.819977,
     "geom:bbox":"104.410874,48.531821,108.574916,50.479269",
     "geom:latitude":49.475889,
     "geom:longitude":106.223984,
@@ -338,17 +338,19 @@
         "gn:id":2029432,
         "gp:id":2346170,
         "hasc:id":"MN.SL",
+        "iso:code":"MN-049",
         "iso:id":"MN-049",
         "qs_pg:id":1046893,
         "unlc:id":"MN-049",
         "wd:id":"Q234680",
         "wk:page":"Selenge Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7007c8e860bab053f2fb835a316ca5f3",
+    "wof:geomhash":"55418e51d89684a8adbbe3eaced1fedb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -363,7 +365,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939691,
+    "wof:lastmodified":1695884440,
     "wof:name":"Selenge",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/65/85674765.geojson
+++ b/data/856/747/65/85674765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.278931,
-    "geom:area_square_m":62699561136.432495,
+    "geom:area_square_m":62699561143.594261,
     "geom:bbox":"101.094219,44.042215,104.661369,47.426653",
     "geom:latitude":45.838031,
     "geom:longitude":102.712733,
@@ -338,17 +338,19 @@
         "gn:id":2029546,
         "gp:id":2346169,
         "hasc:id":"MN.OH",
+        "iso:code":"MN-055",
         "iso:id":"MN-055",
         "qs_pg:id":279891,
         "unlc:id":"MN-055",
         "wd:id":"Q234713",
         "wk:page":"\u00d6v\u00f6rkhangai Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a19a74920498aeea880c7ecbd3a00122",
+    "wof:geomhash":"9b4f0eb7f11baf898096e39321d2a5c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -363,7 +365,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939697,
+    "wof:lastmodified":1695884377,
     "wof:name":"\u00d6v\u00f6rhangay",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/69/85674769.geojson
+++ b/data/856/747/69/85674769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404839,
-    "geom:area_square_m":3256634885.809024,
+    "geom:area_square_m":3256634844.427663,
     "geom:bbox":"105.831499,49.124066,106.81992,49.920553",
     "geom:latitude":49.416174,
     "geom:longitude":106.282034,
@@ -333,16 +333,18 @@
         "gn:id":2055111,
         "gp:id":20070014,
         "hasc:id":"MN.DA",
+        "iso:code":"MN-037",
         "iso:id":"MN-037",
         "qs_pg:id":425212,
         "unlc:id":"MN-037",
         "wd:id":"Q18827"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d83b32cf71eec83a4367719dd3d993ec",
+    "wof:geomhash":"5fefda68a11e5c6674637604862838fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -357,7 +359,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939692,
+    "wof:lastmodified":1695884376,
     "wof:name":"Darhan-Uul",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/77/85674777.geojson
+++ b/data/856/747/77/85674777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.861003,
-    "geom:area_square_m":73767379293.044373,
+    "geom:area_square_m":73767379205.88353,
     "geom:bbox":"104.035931,46.38516,109.054574,49.154561",
     "geom:latitude":47.677484,
     "geom:longitude":106.56622,
@@ -341,17 +341,19 @@
         "gn:id":2028849,
         "gp:id":2346172,
         "hasc:id":"MN.TO",
+        "iso:code":"MN-047",
         "iso:id":"MN-047",
         "qs_pg:id":1285283,
         "unlc:id":"MN-047",
         "wd:id":"Q276195",
         "wk:page":"T\u00f6v Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7acff1ba52d67243b2b0c5ff7dff87b",
+    "wof:geomhash":"07d68850e2a11271bfa02df262221901",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939699,
+    "wof:lastmodified":1695884535,
     "wof:name":"T\u00f6v",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/79/85674779.geojson
+++ b/data/856/747/79/85674779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.649945,
-    "geom:area_square_m":5535253431.899208,
+    "geom:area_square_m":5535253765.09479,
     "geom:bbox":"107.893595,45.882688,109.115129,46.999113",
     "geom:latitude":46.468369,
     "geom:longitude":108.567844,
@@ -325,14 +325,16 @@
         "gn:id":2055112,
         "gp:id":-2346172,
         "hasc:id":"MN.GS",
+        "iso:code":"MN-064",
         "iso:id":"MN-064",
         "wd:id":"Q236333"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a380e16854a2b406c074b8da6c6fbdc3",
+    "wof:geomhash":"519984c96c2b50644e356e0a357961e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -347,7 +349,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939698,
+    "wof:lastmodified":1695884377,
     "wof:name":"Gov\u012d-S\u00fcmber",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/83/85674783.geojson
+++ b/data/856/747/83/85674783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.57053,
-    "geom:area_square_m":4728188446.062414,
+    "geom:area_square_m":4728188154.170774,
     "geom:bbox":"106.366278,47.303975,108.496241,48.27025",
     "geom:latitude":47.916005,
     "geom:longitude":107.164876,
@@ -643,6 +643,7 @@
         "gn:id":2028461,
         "gp:id":20070016,
         "hasc:id":"MN.UB",
+        "iso:code":"MN-1",
         "iso:id":"MN-1",
         "loc:id":"n82211486",
         "qs_pg:id":223783,
@@ -650,11 +651,12 @@
         "wd:id":"Q23430",
         "wk:page":"Ulaanbaatar"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cc7b3af7abb175bb484b6811b2a7d8d1",
+    "wof:geomhash":"636787fd1a3fcc613a94943531eac5ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -669,7 +671,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939699,
+    "wof:lastmodified":1695884377,
     "wof:name":"Ulaanbaatar",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/87/85674787.geojson
+++ b/data/856/747/87/85674787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":14.925789,
-    "geom:area_square_m":123096467407.309387,
+    "geom:area_square_m":123096467536.930313,
     "geom:bbox":"112.074754,46.285924,119.931949,50.285431",
     "geom:latitude":48.158079,
     "geom:longitude":115.465365,
@@ -346,17 +346,19 @@
         "gn:id":2031799,
         "gp:id":2346160,
         "hasc:id":"MN.DD",
+        "iso:code":"MN-061",
         "iso:id":"MN-061",
         "qs_pg:id":211644,
         "unlc:id":"MN-061",
         "wd:id":"Q207795",
         "wk:page":"Dornod Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe10fe5eea43cddb21caa549154bb25c",
+    "wof:geomhash":"fa7694ba3574f1d11177efe43ced3d5b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -371,7 +373,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939695,
+    "wof:lastmodified":1695884377,
     "wof:name":"Dornod",
     "wof:parent_id":85632439,
     "wof:placetype":"region",

--- a/data/856/747/93/85674793.geojson
+++ b/data/856/747/93/85674793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.600924,
-    "geom:area_square_m":82129617578.578476,
+    "geom:area_square_m":82129618126.220764,
     "geom:bbox":"111.220893,44.742889,116.575969,47.825797",
     "geom:latitude":46.222668,
     "geom:longitude":113.543028,
@@ -327,17 +327,19 @@
         "gn:id":2029155,
         "gp:id":2346171,
         "hasc:id":"MN.SB",
+        "iso:code":"MN-051",
         "iso:id":"MN-051",
         "qs_pg:id":984088,
         "unlc:id":"MN-051",
         "wd:id":"Q244804",
         "wk:page":"S\u00fckhbaatar Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5024a77e172519024b275ca25ab720e8",
+    "wof:geomhash":"942201c0c02f4ca58523f4658b317ae8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -352,7 +354,7 @@
     "wof:lang_x_spoken":[
         "mon"
     ],
-    "wof:lastmodified":1690939693,
+    "wof:lastmodified":1695884376,
     "wof:name":"S\u00fchbaatar",
     "wof:parent_id":85632439,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.